### PR TITLE
Respond to pr request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **OpenAPI 3.1 Null Type Preservation** - Fixed parsing of `type: "null"` in OpenAPI 3.1 specs
+  - Previously, `type: "null"` was converted to `nil`, making it indistinguishable from missing type
+  - Now preserves null type as `:null` atom in the Schema struct
+  - Critical for OpenAPI 3.1 nullable patterns using `oneOf` with null type
+  - Includes comprehensive test coverage for null type in various scenarios
+
 ## [0.2.0] - 2025-12-08
 
 ### Added

--- a/lib/openapi_parser/spec/v3/schema.ex
+++ b/lib/openapi_parser/spec/v3/schema.ex
@@ -9,7 +9,7 @@ defmodule OpenapiParser.Spec.V3.Schema do
   alias OpenapiParser.Spec.{ExternalDocumentation, V3}
   alias OpenapiParser.Validation
 
-  @type schema_type :: :string | :number | :integer | :boolean | :array | :object | nil
+  @type schema_type :: :string | :number | :integer | :boolean | :array | :object | :null | nil
 
   # Using any() for complex recursive types to avoid dialyzer issues
   @type t :: %__MODULE__{
@@ -258,7 +258,7 @@ defmodule OpenapiParser.Spec.V3.Schema do
   defp parse_single_type("boolean"), do: :boolean
   defp parse_single_type("array"), do: :array
   defp parse_single_type("object"), do: :object
-  defp parse_single_type("null"), do: nil
+  defp parse_single_type("null"), do: :null
   defp parse_single_type(_), do: nil
 
   defp parse_items(%{"items" => items_data}) when is_map(items_data) do


### PR DESCRIPTION
Fix parsing of `type: "null"` in OpenAPI 3.1 specs to preserve the null type.

Previously, `type: "null"` was converted to `nil`, making it indistinguishable from a missing type. This fix ensures `type: "null"` is correctly parsed as the `:null` atom, which is crucial for OpenAPI 3.1 nullable patterns, especially when used within `oneOf` compositions.

---
<a href="https://cursor.com/background-agent?bcId=bc-a7afb533-9db0-461b-8adc-0080cfe675f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a7afb533-9db0-461b-8adc-0080cfe675f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Parses OpenAPI 3.1 `type: "null"` as `:null` (not `nil`), adds tests for null handling, and updates the changelog.
> 
> - **Parser (V3 Schema)**:
>   - Extend `schema_type` to include `:null` and map `"null"` to `:null` in `parse_single_type`.
>   - Correctly preserves `:null` in `type` arrays and within `oneOf`; distinguishes `:null` from missing `type`.
> - **Tests**:
>   - Add coverage for `type: "null"` (single, array, `oneOf`) and differentiation from missing type in `test/v3_schema_test.exs`.
> - **Docs**:
>   - Update `CHANGELOG.md` under `[Unreleased]` with the null type preservation fix.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3c52824d41ac24a8b4c329beee5bcfeed13fa7a0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->