### PR TITLE
Create github pr

### DIFF
--- a/lib/openapi_parser/key_normalizer.ex
+++ b/lib/openapi_parser/key_normalizer.ex
@@ -1,14 +1,14 @@
 defmodule OpenapiParser.KeyNormalizer do
   @moduledoc """
   Utility module for normalizing map keys from strings to atoms.
-  
+
   This ensures consistent key format throughout the parsed OpenAPI specification,
   eliminating the need for defensive code that checks both atom and string variants.
   """
 
   @doc """
   Normalizes the top-level keys of a map to atoms without recursion.
-  
+
   This is useful for spec constructors that receive data directly.
   """
   @spec normalize_shallow(map()) :: map()
@@ -22,17 +22,17 @@ defmodule OpenapiParser.KeyNormalizer do
 
   @doc """
   Recursively converts all string keys in a map to atoms.
-  
+
   This function handles nested maps and lists of maps, ensuring all string keys
   are converted to atoms for consistent access patterns.
-  
+
   ## Safety
-  
+
   Only known OpenAPI/Swagger keys are converted to atoms to prevent atom table exhaustion.
   Unknown keys are kept as strings for safety.
-  
+
   ## Examples
-  
+
       iex> normalize(%{"name" => "test", "nested" => %{"key" => "value"}})
       %{name: "test", nested: %{key: "value"}}
       
@@ -57,67 +57,176 @@ defmodule OpenapiParser.KeyNormalizer do
   # Known OpenAPI/Swagger keys that should be converted to atoms
   # This list includes all standard fields across all OpenAPI versions
   @known_keys MapSet.new([
-    # Version fields
-    "swagger", "openapi",
-    # Common metadata
-    "info", "title", "version", "summary", "description", "termsOfService",
-    "contact", "name", "url", "email",
-    "license", "identifier",
-    # Server/host fields
-    "servers", "server", "host", "basePath", "schemes", "variables",
-    "enum", "default",
-    # Paths and operations
-    "paths", "get", "put", "post", "delete", "options", "head", "patch", "trace",
-    "parameters", "parameter", "in", "required", "deprecated", "allowEmptyValue",
-    "style", "explode", "allowReserved", "schema", "example", "examples",
-    "content", "encoding", "contentType",
-    # Request/Response
-    "requestBody", "responses", "headers", "links", "callbacks",
-    # Schema fields
-    "type", "format", "properties", "items", "additionalProperties",
-    "patternProperties", "propertyNames", "unevaluatedProperties", "unevaluatedItems",
-    "allOf", "anyOf", "oneOf", "not", "if", "then", "else",
-    "prefixItems", "contains", "minContains", "maxContains",
-    "dependentSchemas", "const",
-    # Validation keywords
-    "maximum", "minimum", "exclusiveMaximum", "exclusiveMinimum", "multipleOf",
-    "maxLength", "minLength", "pattern",
-    "maxItems", "minItems", "uniqueItems",
-    "maxProperties", "minProperties",
-    # Metadata
-    "externalDocs", "tags", "operationId", "consumes", "produces",
-    # Security
-    "security", "securitySchemes", "securityDefinitions", "scheme",
-    "bearerFormat", "flows", "implicit", "password", "clientCredentials",
-    "authorizationCode", "authorizationUrl", "tokenUrl", "refreshUrl", "scopes",
-    "openIdConnectUrl",
-    # Components
-    "components", "schemas", "requestBodies", "securitySchemes",
-    # References
-    "$ref", "$id", "$schema", "$anchor", "$dynamicAnchor", "$dynamicRef",
-    "$comment", "$defs",
-    # OpenAPI specific
-    "discriminator", "readOnly", "writeOnly", "xml", "namespace", "prefix",
-    "attribute", "wrapped", "nullable",
-    # V3 specific
-    "contentEncoding", "contentMediaType", "contentSchema",
-    # Media type
-    "mediaType",
-    # Link fields
-    "operationRef", "operationId",
-    # Encoding
-    "headers",
-    # Path item
-    "summary",
-    # V2 specific
-    "collectionFormat", "location", "flow",
-    # External value
-    "externalValue", "value",
-    # Mapping
-    "mapping", "propertyName",
-    # OAuth
-    "authorizationUrl"
-  ])
+                # Version fields
+                "swagger",
+                "openapi",
+                # Common metadata
+                "info",
+                "title",
+                "version",
+                "summary",
+                "description",
+                "termsOfService",
+                "contact",
+                "name",
+                "url",
+                "email",
+                "license",
+                "identifier",
+                # Server/host fields
+                "servers",
+                "server",
+                "host",
+                "basePath",
+                "schemes",
+                "variables",
+                "enum",
+                "default",
+                # Paths and operations
+                "paths",
+                "webhooks",
+                "get",
+                "put",
+                "post",
+                "delete",
+                "options",
+                "head",
+                "patch",
+                "trace",
+                "parameters",
+                "parameter",
+                "in",
+                "required",
+                "deprecated",
+                "allowEmptyValue",
+                "style",
+                "explode",
+                "allowReserved",
+                "schema",
+                "example",
+                "examples",
+                "content",
+                "encoding",
+                "contentType",
+                # Request/Response
+                "requestBody",
+                "responses",
+                "headers",
+                "links",
+                "callbacks",
+                # Schema fields
+                "type",
+                "format",
+                "properties",
+                "items",
+                "additionalProperties",
+                "patternProperties",
+                "propertyNames",
+                "unevaluatedProperties",
+                "unevaluatedItems",
+                "allOf",
+                "anyOf",
+                "oneOf",
+                "not",
+                "if",
+                "then",
+                "else",
+                "prefixItems",
+                "contains",
+                "minContains",
+                "maxContains",
+                "dependentSchemas",
+                "const",
+                # Validation keywords
+                "maximum",
+                "minimum",
+                "exclusiveMaximum",
+                "exclusiveMinimum",
+                "multipleOf",
+                "maxLength",
+                "minLength",
+                "pattern",
+                "maxItems",
+                "minItems",
+                "uniqueItems",
+                "maxProperties",
+                "minProperties",
+                # Metadata
+                "externalDocs",
+                "tags",
+                "operationId",
+                "consumes",
+                "produces",
+                # Security
+                "security",
+                "securitySchemes",
+                "securityDefinitions",
+                "scheme",
+                "bearerFormat",
+                "flows",
+                "implicit",
+                "password",
+                "clientCredentials",
+                "authorizationCode",
+                "authorizationUrl",
+                "tokenUrl",
+                "refreshUrl",
+                "scopes",
+                "openIdConnectUrl",
+                # Components
+                "components",
+                "schemas",
+                "requestBodies",
+                "securitySchemes",
+                # V2 specific
+                "definitions",
+                "parameters",
+                "responses",
+                # References
+                "$ref",
+                "$id",
+                "$schema",
+                "$anchor",
+                "$dynamicAnchor",
+                "$dynamicRef",
+                "$comment",
+                "$defs",
+                # OpenAPI specific
+                "discriminator",
+                "readOnly",
+                "writeOnly",
+                "xml",
+                "namespace",
+                "prefix",
+                "attribute",
+                "wrapped",
+                "nullable",
+                # V3 specific
+                "contentEncoding",
+                "contentMediaType",
+                "contentSchema",
+                # Media type
+                "mediaType",
+                # Link fields
+                "operationRef",
+                "operationId",
+                # Encoding
+                "headers",
+                # Path item
+                "summary",
+                # V2 specific
+                "collectionFormat",
+                "location",
+                "flow",
+                # External value
+                "externalValue",
+                "value",
+                # Mapping
+                "mapping",
+                "propertyName",
+                # OAuth
+                "authorizationUrl"
+              ])
 
   defp normalize_key(key) when is_binary(key) do
     if MapSet.member?(@known_keys, key) do

--- a/lib/openapi_parser/key_normalizer.ex
+++ b/lib/openapi_parser/key_normalizer.ex
@@ -1,0 +1,138 @@
+defmodule OpenapiParser.KeyNormalizer do
+  @moduledoc """
+  Utility module for normalizing map keys from strings to atoms.
+  
+  This ensures consistent key format throughout the parsed OpenAPI specification,
+  eliminating the need for defensive code that checks both atom and string variants.
+  """
+
+  @doc """
+  Normalizes the top-level keys of a map to atoms without recursion.
+  
+  This is useful for spec constructors that receive data directly.
+  """
+  @spec normalize_shallow(map()) :: map()
+  def normalize_shallow(map) when is_map(map) do
+    map
+    |> Enum.map(fn {key, value} ->
+      {normalize_key(key), value}
+    end)
+    |> Enum.into(%{})
+  end
+
+  @doc """
+  Recursively converts all string keys in a map to atoms.
+  
+  This function handles nested maps and lists of maps, ensuring all string keys
+  are converted to atoms for consistent access patterns.
+  
+  ## Safety
+  
+  Only known OpenAPI/Swagger keys are converted to atoms to prevent atom table exhaustion.
+  Unknown keys are kept as strings for safety.
+  
+  ## Examples
+  
+      iex> normalize(%{"name" => "test", "nested" => %{"key" => "value"}})
+      %{name: "test", nested: %{key: "value"}}
+      
+      iex> normalize(%{"items" => [%{"type" => "string"}]})
+      %{items: [%{type: "string"}]}
+  """
+  @spec normalize(map() | list() | any()) :: map() | list() | any()
+  def normalize(map) when is_map(map) do
+    map
+    |> Enum.map(fn {key, value} ->
+      {normalize_key(key), normalize(value)}
+    end)
+    |> Enum.into(%{})
+  end
+
+  def normalize(list) when is_list(list) do
+    Enum.map(list, &normalize/1)
+  end
+
+  def normalize(value), do: value
+
+  # Known OpenAPI/Swagger keys that should be converted to atoms
+  # This list includes all standard fields across all OpenAPI versions
+  @known_keys MapSet.new([
+    # Version fields
+    "swagger", "openapi",
+    # Common metadata
+    "info", "title", "version", "summary", "description", "termsOfService",
+    "contact", "name", "url", "email",
+    "license", "identifier",
+    # Server/host fields
+    "servers", "server", "host", "basePath", "schemes", "variables",
+    "enum", "default",
+    # Paths and operations
+    "paths", "get", "put", "post", "delete", "options", "head", "patch", "trace",
+    "parameters", "parameter", "in", "required", "deprecated", "allowEmptyValue",
+    "style", "explode", "allowReserved", "schema", "example", "examples",
+    "content", "encoding", "contentType",
+    # Request/Response
+    "requestBody", "responses", "headers", "links", "callbacks",
+    # Schema fields
+    "type", "format", "properties", "items", "additionalProperties",
+    "patternProperties", "propertyNames", "unevaluatedProperties", "unevaluatedItems",
+    "allOf", "anyOf", "oneOf", "not", "if", "then", "else",
+    "prefixItems", "contains", "minContains", "maxContains",
+    "dependentSchemas", "const",
+    # Validation keywords
+    "maximum", "minimum", "exclusiveMaximum", "exclusiveMinimum", "multipleOf",
+    "maxLength", "minLength", "pattern",
+    "maxItems", "minItems", "uniqueItems",
+    "maxProperties", "minProperties",
+    # Metadata
+    "externalDocs", "tags", "operationId", "consumes", "produces",
+    # Security
+    "security", "securitySchemes", "securityDefinitions", "scheme",
+    "bearerFormat", "flows", "implicit", "password", "clientCredentials",
+    "authorizationCode", "authorizationUrl", "tokenUrl", "refreshUrl", "scopes",
+    "openIdConnectUrl",
+    # Components
+    "components", "schemas", "requestBodies", "securitySchemes",
+    # References
+    "$ref", "$id", "$schema", "$anchor", "$dynamicAnchor", "$dynamicRef",
+    "$comment", "$defs",
+    # OpenAPI specific
+    "discriminator", "readOnly", "writeOnly", "xml", "namespace", "prefix",
+    "attribute", "wrapped", "nullable",
+    # V3 specific
+    "contentEncoding", "contentMediaType", "contentSchema",
+    # Media type
+    "mediaType",
+    # Link fields
+    "operationRef", "operationId",
+    # Encoding
+    "headers",
+    # Path item
+    "summary",
+    # V2 specific
+    "collectionFormat", "location", "flow",
+    # External value
+    "externalValue", "value",
+    # Mapping
+    "mapping", "propertyName",
+    # OAuth
+    "authorizationUrl"
+  ])
+
+  defp normalize_key(key) when is_binary(key) do
+    if MapSet.member?(@known_keys, key) do
+      # For keys starting with $, we need to use the :"$key" syntax
+      if String.starts_with?(key, "$") do
+        String.to_atom(key)
+      else
+        String.to_atom(key)
+      end
+    else
+      # Keep unknown keys as strings to avoid atom table exhaustion
+      key
+    end
+  end
+
+  defp normalize_key(key) when is_atom(key), do: key
+  defp normalize_key(key), do: key
+end

--- a/lib/openapi_parser/parser.ex
+++ b/lib/openapi_parser/parser.ex
@@ -8,6 +8,7 @@ defmodule OpenapiParser.Parser do
 
   alias OpenapiParser.Parser.{V2, V3}
   alias OpenapiParser.Spec
+  alias OpenapiParser.KeyNormalizer
 
   @doc """
   Parses an OpenAPI specification from a string.
@@ -59,14 +60,14 @@ defmodule OpenapiParser.Parser do
   defp decode_content(content, :auto) do
     # Try JSON first, then YAML
     case Jason.decode(content) do
-      {:ok, data} -> {:ok, data}
+      {:ok, data} -> {:ok, KeyNormalizer.normalize(data)}
       {:error, _} -> decode_yaml(content)
     end
   end
 
   defp decode_content(content, :json) do
     case Jason.decode(content) do
-      {:ok, data} -> {:ok, data}
+      {:ok, data} -> {:ok, KeyNormalizer.normalize(data)}
       {:error, error} -> {:error, "JSON decode error: #{inspect(error)}"}
     end
   end
@@ -77,7 +78,7 @@ defmodule OpenapiParser.Parser do
 
   defp decode_yaml(content) do
     case YamlElixir.read_from_string(content) do
-      {:ok, data} -> {:ok, data}
+      {:ok, data} -> {:ok, KeyNormalizer.normalize(data)}
       {:error, error} -> {:error, "YAML decode error: #{inspect(error)}"}
     end
   end
@@ -92,12 +93,12 @@ defmodule OpenapiParser.Parser do
 
   defp detect_format_from_path(_path, format), do: format
 
-  defp detect_version(%{"swagger" => "2.0"}), do: {:ok, :v2}
+  defp detect_version(%{swagger: "2.0"}), do: {:ok, :v2}
 
-  defp detect_version(%{"swagger" => version}),
+  defp detect_version(%{swagger: version}),
     do: {:error, "Unsupported Swagger version: #{version}"}
 
-  defp detect_version(%{"openapi" => version}) when is_binary(version) do
+  defp detect_version(%{openapi: version}) when is_binary(version) do
     case String.split(version, ".") do
       ["3", "0" | _] -> {:ok, :v3_0}
       ["3", "1" | _] -> {:ok, :v3_1}

--- a/lib/openapi_parser/parser.ex
+++ b/lib/openapi_parser/parser.ex
@@ -60,14 +60,14 @@ defmodule OpenapiParser.Parser do
   defp decode_content(content, :auto) do
     # Try JSON first, then YAML
     case Jason.decode(content) do
-      {:ok, data} -> {:ok, KeyNormalizer.normalize(data)}
+      {:ok, data} -> {:ok, data}
       {:error, _} -> decode_yaml(content)
     end
   end
 
   defp decode_content(content, :json) do
     case Jason.decode(content) do
-      {:ok, data} -> {:ok, KeyNormalizer.normalize(data)}
+      {:ok, data} -> {:ok, data}
       {:error, error} -> {:error, "JSON decode error: #{inspect(error)}"}
     end
   end
@@ -78,7 +78,7 @@ defmodule OpenapiParser.Parser do
 
   defp decode_yaml(content) do
     case YamlElixir.read_from_string(content) do
-      {:ok, data} -> {:ok, KeyNormalizer.normalize(data)}
+      {:ok, data} -> {:ok, data}
       {:error, error} -> {:error, "YAML decode error: #{inspect(error)}"}
     end
   end
@@ -93,12 +93,12 @@ defmodule OpenapiParser.Parser do
 
   defp detect_format_from_path(_path, format), do: format
 
-  defp detect_version(%{swagger: "2.0"}), do: {:ok, :v2}
+  defp detect_version(%{"swagger" => "2.0"}), do: {:ok, :v2}
 
-  defp detect_version(%{swagger: version}),
+  defp detect_version(%{"swagger" => version}),
     do: {:error, "Unsupported Swagger version: #{version}"}
 
-  defp detect_version(%{openapi: version}) when is_binary(version) do
+  defp detect_version(%{"openapi" => version}) when is_binary(version) do
     case String.split(version, ".") do
       ["3", "0" | _] -> {:ok, :v3_0}
       ["3", "1" | _] -> {:ok, :v3_1}

--- a/lib/openapi_parser/spec/contact.ex
+++ b/lib/openapi_parser/spec/contact.ex
@@ -5,6 +5,7 @@ defmodule OpenapiParser.Spec.Contact do
   Shared across OpenAPI V2, V3.0, and V3.1.
   """
 
+  alias OpenapiParser.KeyNormalizer
   alias OpenapiParser.Validation
 
   @type t :: %__MODULE__{
@@ -20,10 +21,11 @@ defmodule OpenapiParser.Spec.Contact do
   """
   @spec new(map()) :: {:ok, t()} | {:error, String.t()}
   def new(data) when is_map(data) do
+    data = KeyNormalizer.normalize_shallow(data)
     contact = %__MODULE__{
-      name: Map.get(data, "name"),
-      url: Map.get(data, "url"),
-      email: Map.get(data, "email")
+      name: Map.get(data, :name),
+      url: Map.get(data, :url),
+      email: Map.get(data, :email)
     }
 
     {:ok, contact}

--- a/lib/openapi_parser/spec/contact.ex
+++ b/lib/openapi_parser/spec/contact.ex
@@ -22,6 +22,7 @@ defmodule OpenapiParser.Spec.Contact do
   @spec new(map()) :: {:ok, t()} | {:error, String.t()}
   def new(data) when is_map(data) do
     data = KeyNormalizer.normalize_shallow(data)
+
     contact = %__MODULE__{
       name: Map.get(data, :name),
       url: Map.get(data, :url),

--- a/lib/openapi_parser/spec/external_documentation.ex
+++ b/lib/openapi_parser/spec/external_documentation.ex
@@ -21,6 +21,7 @@ defmodule OpenapiParser.Spec.ExternalDocumentation do
   @spec new(map()) :: {:ok, t()} | {:error, String.t()}
   def new(data) when is_map(data) do
     data = KeyNormalizer.normalize_shallow(data)
+
     docs = %__MODULE__{
       url: Map.get(data, :url),
       description: Map.get(data, :description)

--- a/lib/openapi_parser/spec/external_documentation.ex
+++ b/lib/openapi_parser/spec/external_documentation.ex
@@ -5,6 +5,7 @@ defmodule OpenapiParser.Spec.ExternalDocumentation do
   Shared across OpenAPI V2, V3.0, and V3.1.
   """
 
+  alias OpenapiParser.KeyNormalizer
   alias OpenapiParser.Validation
 
   @type t :: %__MODULE__{
@@ -19,9 +20,10 @@ defmodule OpenapiParser.Spec.ExternalDocumentation do
   """
   @spec new(map()) :: {:ok, t()} | {:error, String.t()}
   def new(data) when is_map(data) do
+    data = KeyNormalizer.normalize_shallow(data)
     docs = %__MODULE__{
-      url: Map.get(data, "url"),
-      description: Map.get(data, "description")
+      url: Map.get(data, :url),
+      description: Map.get(data, :description)
     }
 
     {:ok, docs}

--- a/lib/openapi_parser/spec/info.ex
+++ b/lib/openapi_parser/spec/info.ex
@@ -6,6 +6,7 @@ defmodule OpenapiParser.Spec.Info do
   Note: License object varies between versions, so it's handled separately.
   """
 
+  alias OpenapiParser.KeyNormalizer
   alias OpenapiParser.Spec.Contact
   alias OpenapiParser.Validation
 
@@ -28,13 +29,14 @@ defmodule OpenapiParser.Spec.Info do
   """
   @spec new(map()) :: {:ok, t()} | {:error, String.t()}
   def new(data) when is_map(data) do
+    data = KeyNormalizer.normalize_shallow(data)
     with {:ok, contact} <- parse_contact(data) do
       info = %__MODULE__{
-        title: Map.get(data, "title"),
-        version: Map.get(data, "version"),
-        summary: Map.get(data, "summary"),
-        description: Map.get(data, "description"),
-        terms_of_service: Map.get(data, "termsOfService"),
+        title: Map.get(data, :title),
+        version: Map.get(data, :version),
+        summary: Map.get(data, :summary),
+        description: Map.get(data, :description),
+        terms_of_service: Map.get(data, :termsOfService),
         contact: contact,
         license: nil
       }
@@ -43,7 +45,7 @@ defmodule OpenapiParser.Spec.Info do
     end
   end
 
-  defp parse_contact(%{"contact" => contact_data}) when is_map(contact_data) do
+  defp parse_contact(%{:contact => contact_data}) when is_map(contact_data) do
     Contact.new(contact_data)
   end
 

--- a/lib/openapi_parser/spec/info.ex
+++ b/lib/openapi_parser/spec/info.ex
@@ -30,6 +30,7 @@ defmodule OpenapiParser.Spec.Info do
   @spec new(map()) :: {:ok, t()} | {:error, String.t()}
   def new(data) when is_map(data) do
     data = KeyNormalizer.normalize_shallow(data)
+
     with {:ok, contact} <- parse_contact(data) do
       info = %__MODULE__{
         title: Map.get(data, :title),

--- a/lib/openapi_parser/spec/tag.ex
+++ b/lib/openapi_parser/spec/tag.ex
@@ -23,6 +23,7 @@ defmodule OpenapiParser.Spec.Tag do
   @spec new(map()) :: {:ok, t()} | {:error, String.t()}
   def new(data) when is_map(data) do
     data = KeyNormalizer.normalize_shallow(data)
+
     with {:ok, external_docs} <- parse_external_docs(data) do
       tag = %__MODULE__{
         name: Map.get(data, :name),

--- a/lib/openapi_parser/spec/tag.ex
+++ b/lib/openapi_parser/spec/tag.ex
@@ -5,6 +5,7 @@ defmodule OpenapiParser.Spec.Tag do
   Shared across OpenAPI V2, V3.0, and V3.1.
   """
 
+  alias OpenapiParser.KeyNormalizer
   alias OpenapiParser.Spec.ExternalDocumentation
   alias OpenapiParser.Validation
 
@@ -21,10 +22,11 @@ defmodule OpenapiParser.Spec.Tag do
   """
   @spec new(map()) :: {:ok, t()} | {:error, String.t()}
   def new(data) when is_map(data) do
+    data = KeyNormalizer.normalize_shallow(data)
     with {:ok, external_docs} <- parse_external_docs(data) do
       tag = %__MODULE__{
-        name: Map.get(data, "name"),
-        description: Map.get(data, "description"),
+        name: Map.get(data, :name),
+        description: Map.get(data, :description),
         external_docs: external_docs
       }
 
@@ -36,7 +38,7 @@ defmodule OpenapiParser.Spec.Tag do
     {:error, "tag must be a map"}
   end
 
-  defp parse_external_docs(%{"externalDocs" => docs_data}) when is_map(docs_data) do
+  defp parse_external_docs(%{:externalDocs => docs_data}) when is_map(docs_data) do
     ExternalDocumentation.new(docs_data)
   end
 

--- a/lib/openapi_parser/spec/v2/header.ex
+++ b/lib/openapi_parser/spec/v2/header.ex
@@ -3,6 +3,7 @@ defmodule OpenapiParser.Spec.V2.Header do
   Header Object for Swagger 2.0.
   """
 
+  alias OpenapiParser.KeyNormalizer
   alias OpenapiParser.Spec.V2.Schema
   alias OpenapiParser.Validation
 
@@ -53,26 +54,27 @@ defmodule OpenapiParser.Spec.V2.Header do
   """
   @spec new(map()) :: {:ok, t()} | {:error, String.t()}
   def new(data) when is_map(data) do
+    data = KeyNormalizer.normalize_shallow(data)
     with {:ok, items} <- parse_items(data) do
       header = %__MODULE__{
-        description: Map.get(data, "description"),
-        type: parse_type(data["type"]),
-        format: Map.get(data, "format"),
+        description: Map.get(data, :description),
+        type: parse_type(data[:type]),
+        format: Map.get(data, :format),
         items: items,
-        collection_format: Map.get(data, "collectionFormat"),
-        default: Map.get(data, "default"),
-        maximum: Map.get(data, "maximum"),
-        exclusive_maximum: Map.get(data, "exclusiveMaximum"),
-        minimum: Map.get(data, "minimum"),
-        exclusive_minimum: Map.get(data, "exclusiveMinimum"),
-        max_length: Map.get(data, "maxLength"),
-        min_length: Map.get(data, "minLength"),
-        pattern: Map.get(data, "pattern"),
-        max_items: Map.get(data, "maxItems"),
-        min_items: Map.get(data, "minItems"),
-        unique_items: Map.get(data, "uniqueItems"),
-        enum: Map.get(data, "enum"),
-        multiple_of: Map.get(data, "multipleOf")
+        collection_format: Map.get(data, :collectionFormat),
+        default: Map.get(data, :default),
+        maximum: Map.get(data, :maximum),
+        exclusive_maximum: Map.get(data, :exclusiveMaximum),
+        minimum: Map.get(data, :minimum),
+        exclusive_minimum: Map.get(data, :exclusiveMinimum),
+        max_length: Map.get(data, :maxLength),
+        min_length: Map.get(data, :minLength),
+        pattern: Map.get(data, :pattern),
+        max_items: Map.get(data, :maxItems),
+        min_items: Map.get(data, :minItems),
+        unique_items: Map.get(data, :uniqueItems),
+        enum: Map.get(data, :enum),
+        multiple_of: Map.get(data, :multipleOf)
       }
 
       {:ok, header}
@@ -87,7 +89,7 @@ defmodule OpenapiParser.Spec.V2.Header do
   defp parse_type("array"), do: :array
   defp parse_type(_), do: nil
 
-  defp parse_items(%{"items" => items_data}) when is_map(items_data) do
+  defp parse_items(%{:items => items_data}) when is_map(items_data) do
     Schema.new(items_data)
   end
 

--- a/lib/openapi_parser/spec/v2/header.ex
+++ b/lib/openapi_parser/spec/v2/header.ex
@@ -55,6 +55,7 @@ defmodule OpenapiParser.Spec.V2.Header do
   @spec new(map()) :: {:ok, t()} | {:error, String.t()}
   def new(data) when is_map(data) do
     data = KeyNormalizer.normalize_shallow(data)
+
     with {:ok, items} <- parse_items(data) do
       header = %__MODULE__{
         description: Map.get(data, :description),

--- a/lib/openapi_parser/spec/v2/items.ex
+++ b/lib/openapi_parser/spec/v2/items.ex
@@ -54,6 +54,7 @@ defmodule OpenapiParser.Spec.V2.Items do
   @spec new(map()) :: {:ok, t()} | {:error, String.t()}
   def new(data) when is_map(data) do
     data = KeyNormalizer.normalize_shallow(data)
+
     with {:ok, items} <- parse_items(data) do
       items_struct = %__MODULE__{
         type: parse_type(Map.get(data, :type)),

--- a/lib/openapi_parser/spec/v2/items.ex
+++ b/lib/openapi_parser/spec/v2/items.ex
@@ -3,6 +3,7 @@ defmodule OpenapiParser.Spec.V2.Items do
   A limited subset of JSON-Schema's items object for array parameters (Swagger 2.0).
   """
 
+  alias OpenapiParser.KeyNormalizer
   alias OpenapiParser.Validation
 
   @type collection_format :: :csv | :ssv | :tsv | :pipes | :multi
@@ -52,25 +53,26 @@ defmodule OpenapiParser.Spec.V2.Items do
   """
   @spec new(map()) :: {:ok, t()} | {:error, String.t()}
   def new(data) when is_map(data) do
+    data = KeyNormalizer.normalize_shallow(data)
     with {:ok, items} <- parse_items(data) do
       items_struct = %__MODULE__{
-        type: parse_type(Map.get(data, "type")),
-        format: Map.get(data, "format"),
+        type: parse_type(Map.get(data, :type)),
+        format: Map.get(data, :format),
         items: items,
-        collection_format: parse_collection_format(Map.get(data, "collectionFormat")),
-        default: Map.get(data, "default"),
-        maximum: Map.get(data, "maximum"),
-        exclusive_maximum: Map.get(data, "exclusiveMaximum"),
-        minimum: Map.get(data, "minimum"),
-        exclusive_minimum: Map.get(data, "exclusiveMinimum"),
-        max_length: Map.get(data, "maxLength"),
-        min_length: Map.get(data, "minLength"),
-        pattern: Map.get(data, "pattern"),
-        max_items: Map.get(data, "maxItems"),
-        min_items: Map.get(data, "minItems"),
-        unique_items: Map.get(data, "uniqueItems"),
-        enum: Map.get(data, "enum"),
-        multiple_of: Map.get(data, "multipleOf")
+        collection_format: parse_collection_format(Map.get(data, :collectionFormat)),
+        default: Map.get(data, :default),
+        maximum: Map.get(data, :maximum),
+        exclusive_maximum: Map.get(data, :exclusiveMaximum),
+        minimum: Map.get(data, :minimum),
+        exclusive_minimum: Map.get(data, :exclusiveMinimum),
+        max_length: Map.get(data, :maxLength),
+        min_length: Map.get(data, :minLength),
+        pattern: Map.get(data, :pattern),
+        max_items: Map.get(data, :maxItems),
+        min_items: Map.get(data, :minItems),
+        unique_items: Map.get(data, :uniqueItems),
+        enum: Map.get(data, :enum),
+        multiple_of: Map.get(data, :multipleOf)
       }
 
       {:ok, items_struct}
@@ -93,7 +95,7 @@ defmodule OpenapiParser.Spec.V2.Items do
   defp parse_collection_format("multi"), do: :multi
   defp parse_collection_format(_), do: nil
 
-  defp parse_items(%{"items" => items_data}) when is_map(items_data) do
+  defp parse_items(%{:items => items_data}) when is_map(items_data) do
     new(items_data)
   end
 

--- a/lib/openapi_parser/spec/v2/license.ex
+++ b/lib/openapi_parser/spec/v2/license.ex
@@ -3,6 +3,7 @@ defmodule OpenapiParser.Spec.V2.License do
   License information for the exposed API (OpenAPI V2/Swagger 2.0).
   """
 
+  alias OpenapiParser.KeyNormalizer
   alias OpenapiParser.Validation
 
   @type t :: %__MODULE__{
@@ -17,9 +18,10 @@ defmodule OpenapiParser.Spec.V2.License do
   """
   @spec new(map()) :: {:ok, t()} | {:error, String.t()}
   def new(data) when is_map(data) do
+    data = KeyNormalizer.normalize_shallow(data)
     license = %__MODULE__{
-      name: Map.get(data, "name"),
-      url: Map.get(data, "url")
+      name: Map.get(data, :name),
+      url: Map.get(data, :url)
     }
 
     {:ok, license}

--- a/lib/openapi_parser/spec/v2/license.ex
+++ b/lib/openapi_parser/spec/v2/license.ex
@@ -19,6 +19,7 @@ defmodule OpenapiParser.Spec.V2.License do
   @spec new(map()) :: {:ok, t()} | {:error, String.t()}
   def new(data) when is_map(data) do
     data = KeyNormalizer.normalize_shallow(data)
+
     license = %__MODULE__{
       name: Map.get(data, :name),
       url: Map.get(data, :url)

--- a/lib/openapi_parser/spec/v2/operation.ex
+++ b/lib/openapi_parser/spec/v2/operation.ex
@@ -4,6 +4,7 @@ defmodule OpenapiParser.Spec.V2.Operation do
   Describes a single API operation on a path.
   """
 
+  alias OpenapiParser.KeyNormalizer
   alias OpenapiParser.Spec.ExternalDocumentation
   alias OpenapiParser.Spec.V2.{Parameter, Responses, SecurityRequirement}
   alias OpenapiParser.Validation
@@ -43,22 +44,23 @@ defmodule OpenapiParser.Spec.V2.Operation do
   """
   @spec new(map()) :: {:ok, t()} | {:error, String.t()}
   def new(data) when is_map(data) do
+    data = KeyNormalizer.normalize_shallow(data)
     with {:ok, external_docs} <- parse_external_docs(data),
          {:ok, parameters} <- parse_parameters(data),
          {:ok, responses} <- parse_responses(data),
          {:ok, security} <- parse_security(data) do
       operation = %__MODULE__{
-        tags: Map.get(data, "tags"),
-        summary: Map.get(data, "summary"),
-        description: Map.get(data, "description"),
+        tags: Map.get(data, :tags),
+        summary: Map.get(data, :summary),
+        description: Map.get(data, :description),
         external_docs: external_docs,
-        operation_id: Map.get(data, "operationId"),
-        consumes: Map.get(data, "consumes"),
-        produces: Map.get(data, "produces"),
+        operation_id: Map.get(data, :operationId),
+        consumes: Map.get(data, :consumes),
+        produces: Map.get(data, :produces),
         parameters: parameters,
         responses: responses,
-        schemes: Map.get(data, "schemes"),
-        deprecated: Map.get(data, "deprecated"),
+        schemes: Map.get(data, :schemes),
+        deprecated: Map.get(data, :deprecated),
         security: security
       }
 
@@ -66,13 +68,13 @@ defmodule OpenapiParser.Spec.V2.Operation do
     end
   end
 
-  defp parse_external_docs(%{"externalDocs" => docs_data}) when is_map(docs_data) do
+  defp parse_external_docs(%{:externalDocs => docs_data}) when is_map(docs_data) do
     ExternalDocumentation.new(docs_data)
   end
 
   defp parse_external_docs(_), do: {:ok, nil}
 
-  defp parse_parameters(%{"parameters" => params}) when is_list(params) do
+  defp parse_parameters(%{:parameters => params}) when is_list(params) do
     result =
       Enum.reduce_while(params, {:ok, []}, fn param_data, {:ok, acc} ->
         case Parameter.new(param_data) do
@@ -86,13 +88,13 @@ defmodule OpenapiParser.Spec.V2.Operation do
 
   defp parse_parameters(_), do: {:ok, nil}
 
-  defp parse_responses(%{"responses" => responses_data}) when is_map(responses_data) do
+  defp parse_responses(%{:responses => responses_data}) when is_map(responses_data) do
     Responses.new(responses_data)
   end
 
   defp parse_responses(_), do: {:error, "responses is required"}
 
-  defp parse_security(%{"security" => security}) when is_list(security) do
+  defp parse_security(%{:security => security}) when is_list(security) do
     result =
       Enum.reduce_while(security, {:ok, []}, fn sec_data, {:ok, acc} ->
         case SecurityRequirement.new(sec_data) do

--- a/lib/openapi_parser/spec/v2/operation.ex
+++ b/lib/openapi_parser/spec/v2/operation.ex
@@ -45,6 +45,7 @@ defmodule OpenapiParser.Spec.V2.Operation do
   @spec new(map()) :: {:ok, t()} | {:error, String.t()}
   def new(data) when is_map(data) do
     data = KeyNormalizer.normalize_shallow(data)
+
     with {:ok, external_docs} <- parse_external_docs(data),
          {:ok, parameters} <- parse_parameters(data),
          {:ok, responses} <- parse_responses(data),

--- a/lib/openapi_parser/spec/v2/parameter.ex
+++ b/lib/openapi_parser/spec/v2/parameter.ex
@@ -3,6 +3,7 @@ defmodule OpenapiParser.Spec.V2.Parameter do
   Parameter Object for Swagger 2.0.
   """
 
+  alias OpenapiParser.KeyNormalizer
   alias OpenapiParser.Spec.V2.Schema
   alias OpenapiParser.Validation
 
@@ -70,36 +71,37 @@ defmodule OpenapiParser.Spec.V2.Parameter do
   """
   @spec new(map()) :: {:ok, t()} | {:error, String.t()}
   def new(data) when is_map(data) do
+    data = KeyNormalizer.normalize_shallow(data)
     # Handle $ref
-    if Map.has_key?(data, "$ref") do
-      {:ok, %__MODULE__{ref: data["$ref"]}}
+    if Map.has_key?(data, :"$ref") do
+      {:ok, %__MODULE__{ref: data[:"$ref"]}}
     else
       with {:ok, schema} <- parse_schema(data),
            {:ok, items} <- parse_items(data) do
         parameter = %__MODULE__{
-          name: Map.get(data, "name"),
-          location: parse_location(data["in"]),
-          description: Map.get(data, "description"),
-          required: Map.get(data, "required", false),
+          name: Map.get(data, :name),
+          location: parse_location(data[:in]),
+          description: Map.get(data, :description),
+          required: Map.get(data, :required, false),
           schema: schema,
-          type: parse_type(data["type"]),
-          format: Map.get(data, "format"),
-          allow_empty_value: Map.get(data, "allowEmptyValue"),
+          type: parse_type(data[:type]),
+          format: Map.get(data, :format),
+          allow_empty_value: Map.get(data, :allowEmptyValue),
           items: items,
-          collection_format: Map.get(data, "collectionFormat"),
-          default: Map.get(data, "default"),
-          maximum: Map.get(data, "maximum"),
-          exclusive_maximum: Map.get(data, "exclusiveMaximum"),
-          minimum: Map.get(data, "minimum"),
-          exclusive_minimum: Map.get(data, "exclusiveMinimum"),
-          max_length: Map.get(data, "maxLength"),
-          min_length: Map.get(data, "minLength"),
-          pattern: Map.get(data, "pattern"),
-          max_items: Map.get(data, "maxItems"),
-          min_items: Map.get(data, "minItems"),
-          unique_items: Map.get(data, "uniqueItems"),
-          enum: Map.get(data, "enum"),
-          multiple_of: Map.get(data, "multipleOf"),
+          collection_format: Map.get(data, :collectionFormat),
+          default: Map.get(data, :default),
+          maximum: Map.get(data, :maximum),
+          exclusive_maximum: Map.get(data, :exclusiveMaximum),
+          minimum: Map.get(data, :minimum),
+          exclusive_minimum: Map.get(data, :exclusiveMinimum),
+          max_length: Map.get(data, :maxLength),
+          min_length: Map.get(data, :minLength),
+          pattern: Map.get(data, :pattern),
+          max_items: Map.get(data, :maxItems),
+          min_items: Map.get(data, :minItems),
+          unique_items: Map.get(data, :uniqueItems),
+          enum: Map.get(data, :enum),
+          multiple_of: Map.get(data, :multipleOf),
           ref: nil
         }
 
@@ -124,13 +126,13 @@ defmodule OpenapiParser.Spec.V2.Parameter do
   defp parse_type("file"), do: :file
   defp parse_type(_), do: nil
 
-  defp parse_schema(%{"schema" => schema_data}) when is_map(schema_data) do
+  defp parse_schema(%{:schema => schema_data}) when is_map(schema_data) do
     Schema.new(schema_data)
   end
 
   defp parse_schema(_), do: {:ok, nil}
 
-  defp parse_items(%{"items" => items_data}) when is_map(items_data) do
+  defp parse_items(%{:items => items_data}) when is_map(items_data) do
     Schema.new(items_data)
   end
 

--- a/lib/openapi_parser/spec/v2/path_item.ex
+++ b/lib/openapi_parser/spec/v2/path_item.ex
@@ -4,6 +4,7 @@ defmodule OpenapiParser.Spec.V2.PathItem do
   Describes the operations available on a single path.
   """
 
+  alias OpenapiParser.KeyNormalizer
   alias OpenapiParser.Spec.V2.{Operation, Parameter}
   alias OpenapiParser.Validation
 
@@ -26,17 +27,18 @@ defmodule OpenapiParser.Spec.V2.PathItem do
   """
   @spec new(map()) :: {:ok, t()} | {:error, String.t()}
   def new(data) when is_map(data) do
+    data = KeyNormalizer.normalize_shallow(data)
     # Handle $ref
-    if Map.has_key?(data, "$ref") do
-      {:ok, %__MODULE__{ref: data["$ref"]}}
+    if Map.has_key?(data, :"$ref") do
+      {:ok, %__MODULE__{ref: data[:"$ref"]}}
     else
-      with {:ok, get} <- parse_operation(data, "get"),
-           {:ok, put} <- parse_operation(data, "put"),
-           {:ok, post} <- parse_operation(data, "post"),
-           {:ok, delete} <- parse_operation(data, "delete"),
-           {:ok, options} <- parse_operation(data, "options"),
-           {:ok, head} <- parse_operation(data, "head"),
-           {:ok, patch} <- parse_operation(data, "patch"),
+      with {:ok, get} <- parse_operation(data, :get),
+           {:ok, put} <- parse_operation(data, :put),
+           {:ok, post} <- parse_operation(data, :post),
+           {:ok, delete} <- parse_operation(data, :delete),
+           {:ok, options} <- parse_operation(data, :options),
+           {:ok, head} <- parse_operation(data, :head),
+           {:ok, patch} <- parse_operation(data, :patch),
            {:ok, parameters} <- parse_parameters(data) do
         path_item = %__MODULE__{
           get: get,
@@ -62,7 +64,7 @@ defmodule OpenapiParser.Spec.V2.PathItem do
     end
   end
 
-  defp parse_parameters(%{"parameters" => params}) when is_list(params) do
+  defp parse_parameters(%{:parameters => params}) when is_list(params) do
     result =
       Enum.reduce_while(params, {:ok, []}, fn param_data, {:ok, acc} ->
         case Parameter.new(param_data) do

--- a/lib/openapi_parser/spec/v2/responses.ex
+++ b/lib/openapi_parser/spec/v2/responses.ex
@@ -19,7 +19,8 @@ defmodule OpenapiParser.Spec.V2.Responses do
   """
   @spec new(map()) :: {:ok, t()} | {:error, String.t()}
   def new(data) when is_map(data) do
-    data = KeyNormalizer.normalize_shallow(data)
+    # Don't normalize keys here - they are response codes (like "200", "404", "default")
+    # which should remain as strings, not be converted to atoms
     result =
       Enum.reduce_while(data, {:ok, %{}}, fn {key, value}, {:ok, acc} ->
         case Response.new(value) do

--- a/lib/openapi_parser/spec/v2/responses.ex
+++ b/lib/openapi_parser/spec/v2/responses.ex
@@ -4,6 +4,7 @@ defmodule OpenapiParser.Spec.V2.Responses do
   Container for response objects indexed by HTTP status code.
   """
 
+  alias OpenapiParser.KeyNormalizer
   alias OpenapiParser.Spec.V2.Response
   alias OpenapiParser.Validation
 
@@ -18,6 +19,7 @@ defmodule OpenapiParser.Spec.V2.Responses do
   """
   @spec new(map()) :: {:ok, t()} | {:error, String.t()}
   def new(data) when is_map(data) do
+    data = KeyNormalizer.normalize_shallow(data)
     result =
       Enum.reduce_while(data, {:ok, %{}}, fn {key, value}, {:ok, acc} ->
         case Response.new(value) do

--- a/lib/openapi_parser/spec/v2/security_requirement.ex
+++ b/lib/openapi_parser/spec/v2/security_requirement.ex
@@ -20,6 +20,7 @@ defmodule OpenapiParser.Spec.V2.SecurityRequirement do
   @spec new(map()) :: {:ok, t()} | {:error, String.t()}
   def new(data) when is_map(data) do
     data = KeyNormalizer.normalize_shallow(data)
+
     security = %__MODULE__{
       requirements: data
     }

--- a/lib/openapi_parser/spec/v2/security_requirement.ex
+++ b/lib/openapi_parser/spec/v2/security_requirement.ex
@@ -6,6 +6,8 @@ defmodule OpenapiParser.Spec.V2.SecurityRequirement do
   Maps security scheme names to lists of required scopes.
   """
 
+  alias OpenapiParser.KeyNormalizer
+
   @type t :: %__MODULE__{
           requirements: %{String.t() => [String.t()]}
         }
@@ -17,6 +19,7 @@ defmodule OpenapiParser.Spec.V2.SecurityRequirement do
   """
   @spec new(map()) :: {:ok, t()} | {:error, String.t()}
   def new(data) when is_map(data) do
+    data = KeyNormalizer.normalize_shallow(data)
     security = %__MODULE__{
       requirements: data
     }

--- a/lib/openapi_parser/spec/v2/security_scheme.ex
+++ b/lib/openapi_parser/spec/v2/security_scheme.ex
@@ -38,6 +38,7 @@ defmodule OpenapiParser.Spec.V2.SecurityScheme do
   @spec new(map()) :: {:ok, t()} | {:error, String.t()}
   def new(data) when is_map(data) do
     data = KeyNormalizer.normalize_shallow(data)
+
     scheme = %__MODULE__{
       type: parse_type(data[:type]),
       description: Map.get(data, :description),

--- a/lib/openapi_parser/spec/v2/security_scheme.ex
+++ b/lib/openapi_parser/spec/v2/security_scheme.ex
@@ -3,6 +3,7 @@ defmodule OpenapiParser.Spec.V2.SecurityScheme do
   Security Scheme Object for Swagger 2.0.
   """
 
+  alias OpenapiParser.KeyNormalizer
   alias OpenapiParser.Validation
 
   @type scheme_type :: :basic | :apiKey | :oauth2
@@ -36,15 +37,16 @@ defmodule OpenapiParser.Spec.V2.SecurityScheme do
   """
   @spec new(map()) :: {:ok, t()} | {:error, String.t()}
   def new(data) when is_map(data) do
+    data = KeyNormalizer.normalize_shallow(data)
     scheme = %__MODULE__{
-      type: parse_type(data["type"]),
-      description: Map.get(data, "description"),
-      name: Map.get(data, "name"),
-      location: parse_location(data["in"]),
-      flow: parse_flow(data["flow"]),
-      authorization_url: Map.get(data, "authorizationUrl"),
-      token_url: Map.get(data, "tokenUrl"),
-      scopes: Map.get(data, "scopes")
+      type: parse_type(data[:type]),
+      description: Map.get(data, :description),
+      name: Map.get(data, :name),
+      location: parse_location(data[:in]),
+      flow: parse_flow(data[:flow]),
+      authorization_url: Map.get(data, :authorizationUrl),
+      token_url: Map.get(data, :tokenUrl),
+      scopes: Map.get(data, :scopes)
     }
 
     {:ok, scheme}

--- a/lib/openapi_parser/spec/v2/swagger.ex
+++ b/lib/openapi_parser/spec/v2/swagger.ex
@@ -4,6 +4,7 @@ defmodule OpenapiParser.Spec.V2.Swagger do
   This is the root document object for the API specification.
   """
 
+  alias OpenapiParser.KeyNormalizer
   alias OpenapiParser.Spec.{ExternalDocumentation, Info, Tag}
 
   alias OpenapiParser.Spec.V2.{
@@ -58,6 +59,7 @@ defmodule OpenapiParser.Spec.V2.Swagger do
   """
   @spec new(map()) :: {:ok, t()} | {:error, String.t()}
   def new(data) when is_map(data) do
+    data = KeyNormalizer.normalize_shallow(data)
     with {:ok, info} <- parse_info(data),
          {:ok, paths} <- parse_paths(data),
          {:ok, definitions} <- parse_definitions(data),
@@ -68,13 +70,13 @@ defmodule OpenapiParser.Spec.V2.Swagger do
          {:ok, tags} <- parse_tags(data),
          {:ok, external_docs} <- parse_external_docs(data) do
       swagger = %__MODULE__{
-        swagger: Map.get(data, "swagger"),
+        swagger: Map.get(data, :swagger),
         info: info,
-        host: Map.get(data, "host"),
-        base_path: Map.get(data, "basePath"),
-        schemes: Map.get(data, "schemes"),
-        consumes: Map.get(data, "consumes"),
-        produces: Map.get(data, "produces"),
+        host: Map.get(data, :host),
+        base_path: Map.get(data, :basePath),
+        schemes: Map.get(data, :schemes),
+        consumes: Map.get(data, :consumes),
+        produces: Map.get(data, :produces),
         paths: paths,
         definitions: definitions,
         parameters: parameters,
@@ -89,7 +91,7 @@ defmodule OpenapiParser.Spec.V2.Swagger do
     end
   end
 
-  defp parse_info(%{"info" => info_data}) when is_map(info_data) do
+  defp parse_info(%{:info => info_data}) when is_map(info_data) do
     with {:ok, info} <- Info.new(info_data),
          {:ok, license} <- parse_license(info_data) do
       {:ok, %{info | license: license}}
@@ -98,14 +100,14 @@ defmodule OpenapiParser.Spec.V2.Swagger do
 
   defp parse_info(_), do: {:error, "info is required"}
 
-  defp parse_license(%{"license" => license_data}) when is_map(license_data) do
+  defp parse_license(%{:license => license_data}) when is_map(license_data) do
     alias OpenapiParser.Spec.V2.License
     License.new(license_data)
   end
 
   defp parse_license(_), do: {:ok, nil}
 
-  defp parse_paths(%{"paths" => paths}) when is_map(paths) do
+  defp parse_paths(%{:paths => paths}) when is_map(paths) do
     result =
       Enum.reduce_while(paths, {:ok, %{}}, fn {key, value}, {:ok, acc} ->
         case PathItem.new(value) do
@@ -119,7 +121,7 @@ defmodule OpenapiParser.Spec.V2.Swagger do
 
   defp parse_paths(_), do: {:error, "paths is required"}
 
-  defp parse_definitions(%{"definitions" => definitions}) when is_map(definitions) do
+  defp parse_definitions(%{:definitions => definitions}) when is_map(definitions) do
     result =
       Enum.reduce_while(definitions, {:ok, %{}}, fn {key, value}, {:ok, acc} ->
         case Schema.new(value) do
@@ -133,7 +135,7 @@ defmodule OpenapiParser.Spec.V2.Swagger do
 
   defp parse_definitions(_), do: {:ok, nil}
 
-  defp parse_parameters(%{"parameters" => parameters}) when is_map(parameters) do
+  defp parse_parameters(%{:parameters => parameters}) when is_map(parameters) do
     result =
       Enum.reduce_while(parameters, {:ok, %{}}, fn {key, value}, {:ok, acc} ->
         case Parameter.new(value) do
@@ -147,7 +149,7 @@ defmodule OpenapiParser.Spec.V2.Swagger do
 
   defp parse_parameters(_), do: {:ok, nil}
 
-  defp parse_responses(%{"responses" => responses}) when is_map(responses) do
+  defp parse_responses(%{:responses => responses}) when is_map(responses) do
     result =
       Enum.reduce_while(responses, {:ok, %{}}, fn {key, value}, {:ok, acc} ->
         case Response.new(value) do
@@ -161,7 +163,7 @@ defmodule OpenapiParser.Spec.V2.Swagger do
 
   defp parse_responses(_), do: {:ok, nil}
 
-  defp parse_security_definitions(%{"securityDefinitions" => sec_defs}) when is_map(sec_defs) do
+  defp parse_security_definitions(%{:securityDefinitions => sec_defs}) when is_map(sec_defs) do
     result =
       Enum.reduce_while(sec_defs, {:ok, %{}}, fn {key, value}, {:ok, acc} ->
         case SecurityScheme.new(value) do
@@ -175,7 +177,7 @@ defmodule OpenapiParser.Spec.V2.Swagger do
 
   defp parse_security_definitions(_), do: {:ok, nil}
 
-  defp parse_security(%{"security" => security}) when is_list(security) do
+  defp parse_security(%{:security => security}) when is_list(security) do
     result =
       Enum.reduce_while(security, {:ok, []}, fn sec_data, {:ok, acc} ->
         case SecurityRequirement.new(sec_data) do
@@ -189,7 +191,7 @@ defmodule OpenapiParser.Spec.V2.Swagger do
 
   defp parse_security(_), do: {:ok, nil}
 
-  defp parse_tags(%{"tags" => tags}) when is_list(tags) do
+  defp parse_tags(%{:tags => tags}) when is_list(tags) do
     result =
       Enum.reduce_while(tags, {:ok, []}, fn tag_data, {:ok, acc} ->
         case Tag.new(tag_data) do
@@ -203,7 +205,7 @@ defmodule OpenapiParser.Spec.V2.Swagger do
 
   defp parse_tags(_), do: {:ok, nil}
 
-  defp parse_external_docs(%{"externalDocs" => docs_data}) when is_map(docs_data) do
+  defp parse_external_docs(%{:externalDocs => docs_data}) when is_map(docs_data) do
     ExternalDocumentation.new(docs_data)
   end
 

--- a/lib/openapi_parser/spec/v2/swagger.ex
+++ b/lib/openapi_parser/spec/v2/swagger.ex
@@ -60,6 +60,7 @@ defmodule OpenapiParser.Spec.V2.Swagger do
   @spec new(map()) :: {:ok, t()} | {:error, String.t()}
   def new(data) when is_map(data) do
     data = KeyNormalizer.normalize_shallow(data)
+
     with {:ok, info} <- parse_info(data),
          {:ok, paths} <- parse_paths(data),
          {:ok, definitions} <- parse_definitions(data),
@@ -92,8 +93,11 @@ defmodule OpenapiParser.Spec.V2.Swagger do
   end
 
   defp parse_info(%{:info => info_data}) when is_map(info_data) do
+    # Normalize info_data so we can check for :license
+    normalized_info = KeyNormalizer.normalize_shallow(info_data)
+
     with {:ok, info} <- Info.new(info_data),
-         {:ok, license} <- parse_license(info_data) do
+         {:ok, license} <- parse_license(normalized_info) do
       {:ok, %{info | license: license}}
     end
   end

--- a/lib/openapi_parser/spec/v2/xml.ex
+++ b/lib/openapi_parser/spec/v2/xml.ex
@@ -3,6 +3,7 @@ defmodule OpenapiParser.Spec.V2.Xml do
   XML Object for Swagger 2.0.
   """
 
+  alias OpenapiParser.KeyNormalizer
   alias OpenapiParser.Validation
 
   @type t :: %__MODULE__{
@@ -20,12 +21,13 @@ defmodule OpenapiParser.Spec.V2.Xml do
   """
   @spec new(map()) :: {:ok, t()} | {:error, String.t()}
   def new(data) when is_map(data) do
+    data = KeyNormalizer.normalize_shallow(data)
     xml = %__MODULE__{
-      name: Map.get(data, "name"),
-      namespace: Map.get(data, "namespace"),
-      prefix: Map.get(data, "prefix"),
-      attribute: Map.get(data, "attribute"),
-      wrapped: Map.get(data, "wrapped")
+      name: Map.get(data, :name),
+      namespace: Map.get(data, :namespace),
+      prefix: Map.get(data, :prefix),
+      attribute: Map.get(data, :attribute),
+      wrapped: Map.get(data, :wrapped)
     }
 
     {:ok, xml}

--- a/lib/openapi_parser/spec/v2/xml.ex
+++ b/lib/openapi_parser/spec/v2/xml.ex
@@ -22,6 +22,7 @@ defmodule OpenapiParser.Spec.V2.Xml do
   @spec new(map()) :: {:ok, t()} | {:error, String.t()}
   def new(data) when is_map(data) do
     data = KeyNormalizer.normalize_shallow(data)
+
     xml = %__MODULE__{
       name: Map.get(data, :name),
       namespace: Map.get(data, :namespace),

--- a/lib/openapi_parser/spec/v3/callback.ex
+++ b/lib/openapi_parser/spec/v3/callback.ex
@@ -21,6 +21,7 @@ defmodule OpenapiParser.Spec.V3.Callback do
   @spec new(map()) :: {:ok, t()} | {:error, String.t()}
   def new(data) when is_map(data) do
     data = KeyNormalizer.normalize_shallow(data)
+
     result =
       Enum.reduce_while(data, {:ok, %{}}, fn {key, value}, {:ok, acc} ->
         case PathItem.new(value) do

--- a/lib/openapi_parser/spec/v3/callback.ex
+++ b/lib/openapi_parser/spec/v3/callback.ex
@@ -5,6 +5,7 @@ defmodule OpenapiParser.Spec.V3.Callback do
   A map of possible out-of band callbacks related to the parent operation.
   """
 
+  alias OpenapiParser.KeyNormalizer
   alias OpenapiParser.Spec.V3.PathItem
   alias OpenapiParser.Validation
 
@@ -19,6 +20,7 @@ defmodule OpenapiParser.Spec.V3.Callback do
   """
   @spec new(map()) :: {:ok, t()} | {:error, String.t()}
   def new(data) when is_map(data) do
+    data = KeyNormalizer.normalize_shallow(data)
     result =
       Enum.reduce_while(data, {:ok, %{}}, fn {key, value}, {:ok, acc} ->
         case PathItem.new(value) do

--- a/lib/openapi_parser/spec/v3/components.ex
+++ b/lib/openapi_parser/spec/v3/components.ex
@@ -5,6 +5,7 @@ defmodule OpenapiParser.Spec.V3.Components do
   Holds a set of reusable objects for different aspects of the OAS.
   """
 
+  alias OpenapiParser.KeyNormalizer
   alias OpenapiParser.Spec.V3
   alias OpenapiParser.Validation
 
@@ -37,16 +38,17 @@ defmodule OpenapiParser.Spec.V3.Components do
   """
   @spec new(map()) :: {:ok, t()} | {:error, String.t()}
   def new(data) when is_map(data) do
-    with {:ok, schemas} <- parse_component(data, "schemas", &V3.Schema.new/1),
-         {:ok, responses} <- parse_component(data, "responses", &V3.Response.new/1),
-         {:ok, parameters} <- parse_component(data, "parameters", &V3.Parameter.new/1),
-         {:ok, examples} <- parse_component(data, "examples", &V3.Example.new/1),
-         {:ok, request_bodies} <- parse_component(data, "requestBodies", &V3.RequestBody.new/1),
-         {:ok, headers} <- parse_component(data, "headers", &V3.Header.new/1),
+    data = KeyNormalizer.normalize_shallow(data)
+    with {:ok, schemas} <- parse_component(data, :schemas, &V3.Schema.new/1),
+         {:ok, responses} <- parse_component(data, :responses, &V3.Response.new/1),
+         {:ok, parameters} <- parse_component(data, :parameters, &V3.Parameter.new/1),
+         {:ok, examples} <- parse_component(data, :examples, &V3.Example.new/1),
+         {:ok, request_bodies} <- parse_component(data, :requestBodies, &V3.RequestBody.new/1),
+         {:ok, headers} <- parse_component(data, :headers, &V3.Header.new/1),
          {:ok, security_schemes} <-
-           parse_component(data, "securitySchemes", &V3.SecurityScheme.new/1),
-         {:ok, links} <- parse_component(data, "links", &V3.Link.new/1),
-         {:ok, callbacks} <- parse_component(data, "callbacks", &V3.Callback.new/1) do
+           parse_component(data, :securitySchemes, &V3.SecurityScheme.new/1),
+         {:ok, links} <- parse_component(data, :links, &V3.Link.new/1),
+         {:ok, callbacks} <- parse_component(data, :callbacks, &V3.Callback.new/1) do
       components = %__MODULE__{
         schemas: schemas,
         responses: responses,
@@ -73,7 +75,7 @@ defmodule OpenapiParser.Spec.V3.Components do
           Enum.reduce_while(component_map, {:ok, %{}}, fn {name, value}, {:ok, acc} ->
             # Check if it's a reference
             result =
-              if Map.has_key?(value, "$ref") do
+              if Map.has_key?(value, :"$ref") do
                 V3.Reference.new(value)
               else
                 parser_fn.(value)

--- a/lib/openapi_parser/spec/v3/components.ex
+++ b/lib/openapi_parser/spec/v3/components.ex
@@ -39,6 +39,7 @@ defmodule OpenapiParser.Spec.V3.Components do
   @spec new(map()) :: {:ok, t()} | {:error, String.t()}
   def new(data) when is_map(data) do
     data = KeyNormalizer.normalize_shallow(data)
+
     with {:ok, schemas} <- parse_component(data, :schemas, &V3.Schema.new/1),
          {:ok, responses} <- parse_component(data, :responses, &V3.Response.new/1),
          {:ok, parameters} <- parse_component(data, :parameters, &V3.Parameter.new/1),

--- a/lib/openapi_parser/spec/v3/discriminator.ex
+++ b/lib/openapi_parser/spec/v3/discriminator.ex
@@ -22,6 +22,7 @@ defmodule OpenapiParser.Spec.V3.Discriminator do
   @spec new(map()) :: {:ok, t()} | {:error, String.t()}
   def new(data) when is_map(data) do
     data = KeyNormalizer.normalize_shallow(data)
+
     discriminator = %__MODULE__{
       property_name: Map.get(data, :propertyName),
       mapping: Map.get(data, :mapping)

--- a/lib/openapi_parser/spec/v3/discriminator.ex
+++ b/lib/openapi_parser/spec/v3/discriminator.ex
@@ -6,6 +6,7 @@ defmodule OpenapiParser.Spec.V3.Discriminator do
   a discriminator object can be used to aid in serialization, deserialization, and validation.
   """
 
+  alias OpenapiParser.KeyNormalizer
   alias OpenapiParser.Validation
 
   @type t :: %__MODULE__{
@@ -20,9 +21,10 @@ defmodule OpenapiParser.Spec.V3.Discriminator do
   """
   @spec new(map()) :: {:ok, t()} | {:error, String.t()}
   def new(data) when is_map(data) do
+    data = KeyNormalizer.normalize_shallow(data)
     discriminator = %__MODULE__{
-      property_name: Map.get(data, "propertyName"),
-      mapping: Map.get(data, "mapping")
+      property_name: Map.get(data, :propertyName),
+      mapping: Map.get(data, :mapping)
     }
 
     {:ok, discriminator}

--- a/lib/openapi_parser/spec/v3/encoding.ex
+++ b/lib/openapi_parser/spec/v3/encoding.ex
@@ -5,6 +5,7 @@ defmodule OpenapiParser.Spec.V3.Encoding do
   A single encoding definition applied to a single schema property.
   """
 
+  alias OpenapiParser.KeyNormalizer
   alias OpenapiParser.Spec.V3.Header
   alias OpenapiParser.Validation
 
@@ -23,25 +24,26 @@ defmodule OpenapiParser.Spec.V3.Encoding do
   """
   @spec new(map()) :: {:ok, t()} | {:error, String.t()}
   def new(data) when is_map(data) do
+    data = KeyNormalizer.normalize_shallow(data)
     with {:ok, headers} <- parse_headers(data) do
       encoding = %__MODULE__{
-        content_type: Map.get(data, "contentType"),
+        content_type: Map.get(data, :contentType),
         headers: headers,
-        style: Map.get(data, "style"),
-        explode: Map.get(data, "explode"),
-        allow_reserved: Map.get(data, "allowReserved")
+        style: Map.get(data, :style),
+        explode: Map.get(data, :explode),
+        allow_reserved: Map.get(data, :allowReserved)
       }
 
       {:ok, encoding}
     end
   end
 
-  defp parse_headers(%{"headers" => headers}) when is_map(headers) do
+  defp parse_headers(%{:headers => headers}) when is_map(headers) do
     result =
       Enum.reduce_while(headers, {:ok, %{}}, fn {key, value}, {:ok, acc} ->
         # Headers can be Reference or Header objects
         result =
-          if Map.has_key?(value, "$ref") do
+          if Map.has_key?(value, :"$ref") do
             OpenapiParser.Spec.V3.Reference.new(value)
           else
             Header.new(value)

--- a/lib/openapi_parser/spec/v3/encoding.ex
+++ b/lib/openapi_parser/spec/v3/encoding.ex
@@ -25,6 +25,7 @@ defmodule OpenapiParser.Spec.V3.Encoding do
   @spec new(map()) :: {:ok, t()} | {:error, String.t()}
   def new(data) when is_map(data) do
     data = KeyNormalizer.normalize_shallow(data)
+
     with {:ok, headers} <- parse_headers(data) do
       encoding = %__MODULE__{
         content_type: Map.get(data, :contentType),
@@ -41,12 +42,15 @@ defmodule OpenapiParser.Spec.V3.Encoding do
   defp parse_headers(%{:headers => headers}) when is_map(headers) do
     result =
       Enum.reduce_while(headers, {:ok, %{}}, fn {key, value}, {:ok, acc} ->
+        # Normalize the value before checking for $ref
+        normalized_value = KeyNormalizer.normalize_shallow(value)
+
         # Headers can be Reference or Header objects
         result =
-          if Map.has_key?(value, :"$ref") do
-            OpenapiParser.Spec.V3.Reference.new(value)
+          if Map.has_key?(normalized_value, :"$ref") do
+            OpenapiParser.Spec.V3.Reference.new(normalized_value)
           else
-            Header.new(value)
+            Header.new(normalized_value)
           end
 
         case result do

--- a/lib/openapi_parser/spec/v3/example.ex
+++ b/lib/openapi_parser/spec/v3/example.ex
@@ -3,6 +3,7 @@ defmodule OpenapiParser.Spec.V3.Example do
   Example Object for OpenAPI V3.
   """
 
+  alias OpenapiParser.KeyNormalizer
   alias OpenapiParser.Validation
 
   @type t :: %__MODULE__{
@@ -19,11 +20,12 @@ defmodule OpenapiParser.Spec.V3.Example do
   """
   @spec new(map()) :: {:ok, t()} | {:error, String.t()}
   def new(data) when is_map(data) do
+    data = KeyNormalizer.normalize_shallow(data)
     example = %__MODULE__{
-      summary: Map.get(data, "summary"),
-      description: Map.get(data, "description"),
-      value: Map.get(data, "value"),
-      external_value: Map.get(data, "externalValue")
+      summary: Map.get(data, :summary),
+      description: Map.get(data, :description),
+      value: Map.get(data, :value),
+      external_value: Map.get(data, :externalValue)
     }
 
     {:ok, example}

--- a/lib/openapi_parser/spec/v3/example.ex
+++ b/lib/openapi_parser/spec/v3/example.ex
@@ -21,6 +21,7 @@ defmodule OpenapiParser.Spec.V3.Example do
   @spec new(map()) :: {:ok, t()} | {:error, String.t()}
   def new(data) when is_map(data) do
     data = KeyNormalizer.normalize_shallow(data)
+
     example = %__MODULE__{
       summary: Map.get(data, :summary),
       description: Map.get(data, :description),

--- a/lib/openapi_parser/spec/v3/header.ex
+++ b/lib/openapi_parser/spec/v3/header.ex
@@ -3,6 +3,7 @@ defmodule OpenapiParser.Spec.V3.Header do
   Header Object for OpenAPI V3.
   """
 
+  alias OpenapiParser.KeyNormalizer
   alias OpenapiParser.Spec.V3.{Example, Reference, Schema}
   alias OpenapiParser.Validation
 
@@ -38,18 +39,19 @@ defmodule OpenapiParser.Spec.V3.Header do
   """
   @spec new(map()) :: {:ok, t()} | {:error, String.t()}
   def new(data) when is_map(data) do
+    data = KeyNormalizer.normalize_shallow(data)
     with {:ok, schema} <- parse_schema(data),
          {:ok, examples} <- parse_examples(data) do
       header = %__MODULE__{
-        description: Map.get(data, "description"),
-        required: Map.get(data, "required", false),
-        deprecated: Map.get(data, "deprecated"),
-        allow_empty_value: Map.get(data, "allowEmptyValue"),
-        style: Map.get(data, "style"),
-        explode: Map.get(data, "explode"),
-        allow_reserved: Map.get(data, "allowReserved"),
+        description: Map.get(data, :description),
+        required: Map.get(data, :required, false),
+        deprecated: Map.get(data, :deprecated),
+        allow_empty_value: Map.get(data, :allowEmptyValue),
+        style: Map.get(data, :style),
+        explode: Map.get(data, :explode),
+        allow_reserved: Map.get(data, :allowReserved),
         schema: schema,
-        example: Map.get(data, "example"),
+        example: Map.get(data, :example),
         examples: examples
       }
 
@@ -57,17 +59,17 @@ defmodule OpenapiParser.Spec.V3.Header do
     end
   end
 
-  defp parse_schema(%{"schema" => schema_data}) when is_map(schema_data) do
+  defp parse_schema(%{:schema => schema_data}) when is_map(schema_data) do
     Schema.new(schema_data)
   end
 
   defp parse_schema(_), do: {:ok, nil}
 
-  defp parse_examples(%{"examples" => examples}) when is_map(examples) do
+  defp parse_examples(%{:examples => examples}) when is_map(examples) do
     result =
       Enum.reduce_while(examples, {:ok, %{}}, fn {key, value}, {:ok, acc} ->
         result =
-          if Map.has_key?(value, "$ref") do
+          if Map.has_key?(value, :"$ref") do
             Reference.new(value)
           else
             Example.new(value)

--- a/lib/openapi_parser/spec/v3/header.ex
+++ b/lib/openapi_parser/spec/v3/header.ex
@@ -40,6 +40,7 @@ defmodule OpenapiParser.Spec.V3.Header do
   @spec new(map()) :: {:ok, t()} | {:error, String.t()}
   def new(data) when is_map(data) do
     data = KeyNormalizer.normalize_shallow(data)
+
     with {:ok, schema} <- parse_schema(data),
          {:ok, examples} <- parse_examples(data) do
       header = %__MODULE__{
@@ -68,11 +69,14 @@ defmodule OpenapiParser.Spec.V3.Header do
   defp parse_examples(%{:examples => examples}) when is_map(examples) do
     result =
       Enum.reduce_while(examples, {:ok, %{}}, fn {key, value}, {:ok, acc} ->
+        # Normalize the value before checking for $ref
+        normalized_value = KeyNormalizer.normalize_shallow(value)
+
         result =
-          if Map.has_key?(value, :"$ref") do
-            Reference.new(value)
+          if Map.has_key?(normalized_value, :"$ref") do
+            Reference.new(normalized_value)
           else
-            Example.new(value)
+            Example.new(normalized_value)
           end
 
         case result do

--- a/lib/openapi_parser/spec/v3/license.ex
+++ b/lib/openapi_parser/spec/v3/license.ex
@@ -22,6 +22,7 @@ defmodule OpenapiParser.Spec.V3.License do
   @spec new(map()) :: {:ok, t()} | {:error, String.t()}
   def new(data) when is_map(data) do
     data = KeyNormalizer.normalize_shallow(data)
+
     license = %__MODULE__{
       name: Map.get(data, :name),
       url: Map.get(data, :url),

--- a/lib/openapi_parser/spec/v3/license.ex
+++ b/lib/openapi_parser/spec/v3/license.ex
@@ -5,6 +5,7 @@ defmodule OpenapiParser.Spec.V3.License do
   V3.1 adds the optional `identifier` field for SPDX license identifiers.
   """
 
+  alias OpenapiParser.KeyNormalizer
   alias OpenapiParser.Validation
 
   @type t :: %__MODULE__{
@@ -20,10 +21,11 @@ defmodule OpenapiParser.Spec.V3.License do
   """
   @spec new(map()) :: {:ok, t()} | {:error, String.t()}
   def new(data) when is_map(data) do
+    data = KeyNormalizer.normalize_shallow(data)
     license = %__MODULE__{
-      name: Map.get(data, "name"),
-      url: Map.get(data, "url"),
-      identifier: Map.get(data, "identifier")
+      name: Map.get(data, :name),
+      url: Map.get(data, :url),
+      identifier: Map.get(data, :identifier)
     }
 
     {:ok, license}

--- a/lib/openapi_parser/spec/v3/link.ex
+++ b/lib/openapi_parser/spec/v3/link.ex
@@ -26,6 +26,7 @@ defmodule OpenapiParser.Spec.V3.Link do
   @spec new(map()) :: {:ok, t()} | {:error, String.t()}
   def new(data) when is_map(data) do
     data = KeyNormalizer.normalize_shallow(data)
+
     with {:ok, server} <- parse_server(data) do
       link = %__MODULE__{
         operation_ref: Map.get(data, :operationRef),

--- a/lib/openapi_parser/spec/v3/link.ex
+++ b/lib/openapi_parser/spec/v3/link.ex
@@ -5,6 +5,7 @@ defmodule OpenapiParser.Spec.V3.Link do
   Represents a possible design-time link for a response.
   """
 
+  alias OpenapiParser.KeyNormalizer
   alias OpenapiParser.Spec.V3.Server
   alias OpenapiParser.Validation
 
@@ -24,13 +25,14 @@ defmodule OpenapiParser.Spec.V3.Link do
   """
   @spec new(map()) :: {:ok, t()} | {:error, String.t()}
   def new(data) when is_map(data) do
+    data = KeyNormalizer.normalize_shallow(data)
     with {:ok, server} <- parse_server(data) do
       link = %__MODULE__{
-        operation_ref: Map.get(data, "operationRef"),
-        operation_id: Map.get(data, "operationId"),
-        parameters: Map.get(data, "parameters"),
-        request_body: Map.get(data, "requestBody"),
-        description: Map.get(data, "description"),
+        operation_ref: Map.get(data, :operationRef),
+        operation_id: Map.get(data, :operationId),
+        parameters: Map.get(data, :parameters),
+        request_body: Map.get(data, :requestBody),
+        description: Map.get(data, :description),
         server: server
       }
 
@@ -38,7 +40,7 @@ defmodule OpenapiParser.Spec.V3.Link do
     end
   end
 
-  defp parse_server(%{"server" => server_data}) when is_map(server_data) do
+  defp parse_server(%{:server => server_data}) when is_map(server_data) do
     Server.new(server_data)
   end
 

--- a/lib/openapi_parser/spec/v3/media_type.ex
+++ b/lib/openapi_parser/spec/v3/media_type.ex
@@ -24,6 +24,7 @@ defmodule OpenapiParser.Spec.V3.MediaType do
   @spec new(map()) :: {:ok, t()} | {:error, String.t()}
   def new(data) when is_map(data) do
     data = KeyNormalizer.normalize_shallow(data)
+
     with {:ok, schema} <- parse_schema(data),
          {:ok, examples} <- parse_examples(data),
          {:ok, encoding} <- parse_encoding(data) do

--- a/lib/openapi_parser/spec/v3/oauth_flow.ex
+++ b/lib/openapi_parser/spec/v3/oauth_flow.ex
@@ -23,6 +23,7 @@ defmodule OpenapiParser.Spec.V3.OAuthFlow do
   @spec new(map()) :: {:ok, t()} | {:error, String.t()}
   def new(data) when is_map(data) do
     data = KeyNormalizer.normalize_shallow(data)
+
     flow = %__MODULE__{
       authorization_url: Map.get(data, :authorizationUrl),
       token_url: Map.get(data, :tokenUrl),

--- a/lib/openapi_parser/spec/v3/oauth_flow.ex
+++ b/lib/openapi_parser/spec/v3/oauth_flow.ex
@@ -5,6 +5,7 @@ defmodule OpenapiParser.Spec.V3.OAuthFlow do
   Configuration details for a supported OAuth Flow.
   """
 
+  alias OpenapiParser.KeyNormalizer
   alias OpenapiParser.Validation
 
   @type t :: %__MODULE__{
@@ -21,11 +22,12 @@ defmodule OpenapiParser.Spec.V3.OAuthFlow do
   """
   @spec new(map()) :: {:ok, t()} | {:error, String.t()}
   def new(data) when is_map(data) do
+    data = KeyNormalizer.normalize_shallow(data)
     flow = %__MODULE__{
-      authorization_url: Map.get(data, "authorizationUrl"),
-      token_url: Map.get(data, "tokenUrl"),
-      refresh_url: Map.get(data, "refreshUrl"),
-      scopes: Map.get(data, "scopes", %{})
+      authorization_url: Map.get(data, :authorizationUrl),
+      token_url: Map.get(data, :tokenUrl),
+      refresh_url: Map.get(data, :refreshUrl),
+      scopes: Map.get(data, :scopes, %{})
     }
 
     {:ok, flow}

--- a/lib/openapi_parser/spec/v3/oauth_flows.ex
+++ b/lib/openapi_parser/spec/v3/oauth_flows.ex
@@ -5,6 +5,7 @@ defmodule OpenapiParser.Spec.V3.OAuthFlows do
   Allows configuration of the supported OAuth Flows.
   """
 
+  alias OpenapiParser.KeyNormalizer
   alias OpenapiParser.Spec.V3.OAuthFlow
   alias OpenapiParser.Validation
 
@@ -22,10 +23,11 @@ defmodule OpenapiParser.Spec.V3.OAuthFlows do
   """
   @spec new(map()) :: {:ok, t()} | {:error, String.t()}
   def new(data) when is_map(data) do
-    with {:ok, implicit} <- parse_flow(data, "implicit"),
-         {:ok, password} <- parse_flow(data, "password"),
-         {:ok, client_credentials} <- parse_flow(data, "clientCredentials"),
-         {:ok, authorization_code} <- parse_flow(data, "authorizationCode") do
+    data = KeyNormalizer.normalize_shallow(data)
+    with {:ok, implicit} <- parse_flow(data, :implicit),
+         {:ok, password} <- parse_flow(data, :password),
+         {:ok, client_credentials} <- parse_flow(data, :clientCredentials),
+         {:ok, authorization_code} <- parse_flow(data, :authorizationCode) do
       flows = %__MODULE__{
         implicit: implicit,
         password: password,

--- a/lib/openapi_parser/spec/v3/oauth_flows.ex
+++ b/lib/openapi_parser/spec/v3/oauth_flows.ex
@@ -24,6 +24,7 @@ defmodule OpenapiParser.Spec.V3.OAuthFlows do
   @spec new(map()) :: {:ok, t()} | {:error, String.t()}
   def new(data) when is_map(data) do
     data = KeyNormalizer.normalize_shallow(data)
+
     with {:ok, implicit} <- parse_flow(data, :implicit),
          {:ok, password} <- parse_flow(data, :password),
          {:ok, client_credentials} <- parse_flow(data, :clientCredentials),

--- a/lib/openapi_parser/spec/v3/openapi.ex
+++ b/lib/openapi_parser/spec/v3/openapi.ex
@@ -39,6 +39,7 @@ defmodule OpenapiParser.Spec.V3.OpenAPI do
   @spec new(map()) :: {:ok, t()} | {:error, String.t()}
   def new(data) when is_map(data) do
     data = KeyNormalizer.normalize_shallow(data)
+
     with {:ok, info} <- parse_info(data),
          {:ok, servers} <- parse_servers(data),
          {:ok, paths} <- parse_paths(data),
@@ -64,8 +65,11 @@ defmodule OpenapiParser.Spec.V3.OpenAPI do
   end
 
   defp parse_info(%{:info => info_data}) when is_map(info_data) do
+    # Normalize info_data so we can check for :license
+    normalized_info = KeyNormalizer.normalize_shallow(info_data)
+
     with {:ok, info} <- Info.new(info_data),
-         {:ok, license} <- parse_license(info_data) do
+         {:ok, license} <- parse_license(normalized_info) do
       {:ok, %{info | license: license}}
     end
   end

--- a/lib/openapi_parser/spec/v3/openapi.ex
+++ b/lib/openapi_parser/spec/v3/openapi.ex
@@ -5,6 +5,7 @@ defmodule OpenapiParser.Spec.V3.OpenAPI do
   This is the root document object for the API specification.
   """
 
+  alias OpenapiParser.KeyNormalizer
   alias OpenapiParser.Spec.{ExternalDocumentation, Info, Tag, V3}
   alias OpenapiParser.Validation
 
@@ -37,6 +38,7 @@ defmodule OpenapiParser.Spec.V3.OpenAPI do
   """
   @spec new(map()) :: {:ok, t()} | {:error, String.t()}
   def new(data) when is_map(data) do
+    data = KeyNormalizer.normalize_shallow(data)
     with {:ok, info} <- parse_info(data),
          {:ok, servers} <- parse_servers(data),
          {:ok, paths} <- parse_paths(data),
@@ -46,7 +48,7 @@ defmodule OpenapiParser.Spec.V3.OpenAPI do
          {:ok, tags} <- parse_tags(data),
          {:ok, external_docs} <- parse_external_docs(data) do
       openapi = %__MODULE__{
-        openapi: Map.get(data, "openapi"),
+        openapi: Map.get(data, :openapi),
         info: info,
         servers: servers,
         paths: paths,
@@ -61,7 +63,7 @@ defmodule OpenapiParser.Spec.V3.OpenAPI do
     end
   end
 
-  defp parse_info(%{"info" => info_data}) when is_map(info_data) do
+  defp parse_info(%{:info => info_data}) when is_map(info_data) do
     with {:ok, info} <- Info.new(info_data),
          {:ok, license} <- parse_license(info_data) do
       {:ok, %{info | license: license}}
@@ -70,13 +72,13 @@ defmodule OpenapiParser.Spec.V3.OpenAPI do
 
   defp parse_info(_), do: {:error, "info is required"}
 
-  defp parse_license(%{"license" => license_data}) when is_map(license_data) do
+  defp parse_license(%{:license => license_data}) when is_map(license_data) do
     V3.License.new(license_data)
   end
 
   defp parse_license(_), do: {:ok, nil}
 
-  defp parse_servers(%{"servers" => servers}) when is_list(servers) do
+  defp parse_servers(%{:servers => servers}) when is_list(servers) do
     result =
       Enum.reduce_while(servers, {:ok, []}, fn server_data, {:ok, acc} ->
         case V3.Server.new(server_data) do
@@ -90,11 +92,11 @@ defmodule OpenapiParser.Spec.V3.OpenAPI do
 
   defp parse_servers(_), do: {:ok, nil}
 
-  defp parse_paths(%{"paths" => paths}) when is_map(paths) do
+  defp parse_paths(%{:paths => paths}) when is_map(paths) do
     result =
       Enum.reduce_while(paths, {:ok, %{}}, fn {key, value}, {:ok, acc} ->
         result =
-          if Map.has_key?(value, "$ref") do
+          if Map.has_key?(value, :"$ref") do
             V3.Reference.new(value)
           else
             V3.PathItem.new(value)
@@ -111,11 +113,11 @@ defmodule OpenapiParser.Spec.V3.OpenAPI do
 
   defp parse_paths(_), do: {:ok, nil}
 
-  defp parse_webhooks(%{"webhooks" => webhooks}) when is_map(webhooks) do
+  defp parse_webhooks(%{:webhooks => webhooks}) when is_map(webhooks) do
     result =
       Enum.reduce_while(webhooks, {:ok, %{}}, fn {key, value}, {:ok, acc} ->
         result =
-          if Map.has_key?(value, "$ref") do
+          if Map.has_key?(value, :"$ref") do
             V3.Reference.new(value)
           else
             V3.PathItem.new(value)
@@ -132,13 +134,13 @@ defmodule OpenapiParser.Spec.V3.OpenAPI do
 
   defp parse_webhooks(_), do: {:ok, nil}
 
-  defp parse_components(%{"components" => components_data}) when is_map(components_data) do
+  defp parse_components(%{:components => components_data}) when is_map(components_data) do
     V3.Components.new(components_data)
   end
 
   defp parse_components(_), do: {:ok, nil}
 
-  defp parse_security(%{"security" => security}) when is_list(security) do
+  defp parse_security(%{:security => security}) when is_list(security) do
     result =
       Enum.reduce_while(security, {:ok, []}, fn sec_data, {:ok, acc} ->
         case V3.SecurityRequirement.new(sec_data) do
@@ -152,7 +154,7 @@ defmodule OpenapiParser.Spec.V3.OpenAPI do
 
   defp parse_security(_), do: {:ok, nil}
 
-  defp parse_tags(%{"tags" => tags}) when is_list(tags) do
+  defp parse_tags(%{:tags => tags}) when is_list(tags) do
     result =
       Enum.reduce_while(tags, {:ok, []}, fn tag_data, {:ok, acc} ->
         case Tag.new(tag_data) do
@@ -166,7 +168,7 @@ defmodule OpenapiParser.Spec.V3.OpenAPI do
 
   defp parse_tags(_), do: {:ok, nil}
 
-  defp parse_external_docs(%{"externalDocs" => docs_data}) when is_map(docs_data) do
+  defp parse_external_docs(%{:externalDocs => docs_data}) when is_map(docs_data) do
     ExternalDocumentation.new(docs_data)
   end
 

--- a/lib/openapi_parser/spec/v3/operation.ex
+++ b/lib/openapi_parser/spec/v3/operation.ex
@@ -5,6 +5,7 @@ defmodule OpenapiParser.Spec.V3.Operation do
   Describes a single API operation on a path.
   """
 
+  alias OpenapiParser.KeyNormalizer
   alias OpenapiParser.Spec.{ExternalDocumentation, V3}
   alias OpenapiParser.Validation
 
@@ -43,6 +44,7 @@ defmodule OpenapiParser.Spec.V3.Operation do
   """
   @spec new(map()) :: {:ok, t()} | {:error, String.t()}
   def new(data) when is_map(data) do
+    data = KeyNormalizer.normalize_shallow(data)
     with {:ok, external_docs} <- parse_external_docs(data),
          {:ok, parameters} <- parse_parameters(data),
          {:ok, request_body} <- parse_request_body(data),
@@ -51,16 +53,16 @@ defmodule OpenapiParser.Spec.V3.Operation do
          {:ok, security} <- parse_security(data),
          {:ok, servers} <- parse_servers(data) do
       operation = %__MODULE__{
-        tags: Map.get(data, "tags"),
-        summary: Map.get(data, "summary"),
-        description: Map.get(data, "description"),
+        tags: Map.get(data, :tags),
+        summary: Map.get(data, :summary),
+        description: Map.get(data, :description),
         external_docs: external_docs,
-        operation_id: Map.get(data, "operationId"),
+        operation_id: Map.get(data, :operationId),
         parameters: parameters,
         request_body: request_body,
         responses: responses,
         callbacks: callbacks,
-        deprecated: Map.get(data, "deprecated"),
+        deprecated: Map.get(data, :deprecated),
         security: security,
         servers: servers
       }
@@ -69,17 +71,17 @@ defmodule OpenapiParser.Spec.V3.Operation do
     end
   end
 
-  defp parse_external_docs(%{"externalDocs" => docs_data}) when is_map(docs_data) do
+  defp parse_external_docs(%{:externalDocs => docs_data}) when is_map(docs_data) do
     ExternalDocumentation.new(docs_data)
   end
 
   defp parse_external_docs(_), do: {:ok, nil}
 
-  defp parse_parameters(%{"parameters" => params}) when is_list(params) do
+  defp parse_parameters(%{:parameters => params}) when is_list(params) do
     result =
       Enum.reduce_while(params, {:ok, []}, fn param_data, {:ok, acc} ->
         result =
-          if Map.has_key?(param_data, "$ref") do
+          if Map.has_key?(param_data, :"$ref") do
             V3.Reference.new(param_data)
           else
             V3.Parameter.new(param_data)
@@ -96,8 +98,8 @@ defmodule OpenapiParser.Spec.V3.Operation do
 
   defp parse_parameters(_), do: {:ok, nil}
 
-  defp parse_request_body(%{"requestBody" => body_data}) when is_map(body_data) do
-    if Map.has_key?(body_data, "$ref") do
+  defp parse_request_body(%{:requestBody => body_data}) when is_map(body_data) do
+    if Map.has_key?(body_data, :"$ref") do
       V3.Reference.new(body_data)
     else
       V3.RequestBody.new(body_data)
@@ -106,17 +108,17 @@ defmodule OpenapiParser.Spec.V3.Operation do
 
   defp parse_request_body(_), do: {:ok, nil}
 
-  defp parse_responses(%{"responses" => responses_data}) when is_map(responses_data) do
+  defp parse_responses(%{:responses => responses_data}) when is_map(responses_data) do
     V3.Responses.new(responses_data)
   end
 
   defp parse_responses(_), do: {:error, "responses is required"}
 
-  defp parse_callbacks(%{"callbacks" => callbacks}) when is_map(callbacks) do
+  defp parse_callbacks(%{:callbacks => callbacks}) when is_map(callbacks) do
     result =
       Enum.reduce_while(callbacks, {:ok, %{}}, fn {key, value}, {:ok, acc} ->
         result =
-          if Map.has_key?(value, "$ref") do
+          if Map.has_key?(value, :"$ref") do
             V3.Reference.new(value)
           else
             V3.Callback.new(value)
@@ -133,7 +135,7 @@ defmodule OpenapiParser.Spec.V3.Operation do
 
   defp parse_callbacks(_), do: {:ok, nil}
 
-  defp parse_security(%{"security" => security}) when is_list(security) do
+  defp parse_security(%{:security => security}) when is_list(security) do
     result =
       Enum.reduce_while(security, {:ok, []}, fn sec_data, {:ok, acc} ->
         case V3.SecurityRequirement.new(sec_data) do
@@ -147,7 +149,7 @@ defmodule OpenapiParser.Spec.V3.Operation do
 
   defp parse_security(_), do: {:ok, nil}
 
-  defp parse_servers(%{"servers" => servers}) when is_list(servers) do
+  defp parse_servers(%{:servers => servers}) when is_list(servers) do
     result =
       Enum.reduce_while(servers, {:ok, []}, fn server_data, {:ok, acc} ->
         case V3.Server.new(server_data) do

--- a/lib/openapi_parser/spec/v3/parameter.ex
+++ b/lib/openapi_parser/spec/v3/parameter.ex
@@ -50,6 +50,7 @@ defmodule OpenapiParser.Spec.V3.Parameter do
   @spec new(map()) :: {:ok, t()} | {:error, String.t()}
   def new(data) when is_map(data) do
     data = KeyNormalizer.normalize_shallow(data)
+
     with {:ok, schema} <- parse_schema(data),
          {:ok, examples} <- parse_examples(data),
          {:ok, content} <- parse_content(data) do
@@ -88,11 +89,14 @@ defmodule OpenapiParser.Spec.V3.Parameter do
   defp parse_examples(%{:examples => examples}) when is_map(examples) do
     result =
       Enum.reduce_while(examples, {:ok, %{}}, fn {key, value}, {:ok, acc} ->
+        # Normalize the value before checking for $ref
+        normalized_value = KeyNormalizer.normalize_shallow(value)
+
         result =
-          if Map.has_key?(value, :"$ref") do
-            Reference.new(value)
+          if Map.has_key?(normalized_value, :"$ref") do
+            Reference.new(normalized_value)
           else
-            Example.new(value)
+            Example.new(normalized_value)
           end
 
         case result do

--- a/lib/openapi_parser/spec/v3/parameter.ex
+++ b/lib/openapi_parser/spec/v3/parameter.ex
@@ -5,6 +5,7 @@ defmodule OpenapiParser.Spec.V3.Parameter do
   Describes a single operation parameter.
   """
 
+  alias OpenapiParser.KeyNormalizer
   alias OpenapiParser.Spec.V3.{Example, MediaType, Reference, Schema}
   alias OpenapiParser.Validation
 
@@ -48,21 +49,22 @@ defmodule OpenapiParser.Spec.V3.Parameter do
   """
   @spec new(map()) :: {:ok, t()} | {:error, String.t()}
   def new(data) when is_map(data) do
+    data = KeyNormalizer.normalize_shallow(data)
     with {:ok, schema} <- parse_schema(data),
          {:ok, examples} <- parse_examples(data),
          {:ok, content} <- parse_content(data) do
       parameter = %__MODULE__{
-        name: Map.get(data, "name"),
-        location: parse_location(data["in"]),
-        description: Map.get(data, "description"),
-        required: Map.get(data, "required", false),
-        deprecated: Map.get(data, "deprecated"),
-        allow_empty_value: Map.get(data, "allowEmptyValue"),
-        style: Map.get(data, "style"),
-        explode: Map.get(data, "explode"),
-        allow_reserved: Map.get(data, "allowReserved"),
+        name: Map.get(data, :name),
+        location: parse_location(data[:in]),
+        description: Map.get(data, :description),
+        required: Map.get(data, :required, false),
+        deprecated: Map.get(data, :deprecated),
+        allow_empty_value: Map.get(data, :allowEmptyValue),
+        style: Map.get(data, :style),
+        explode: Map.get(data, :explode),
+        allow_reserved: Map.get(data, :allowReserved),
         schema: schema,
-        example: Map.get(data, "example"),
+        example: Map.get(data, :example),
         examples: examples,
         content: content
       }
@@ -77,17 +79,17 @@ defmodule OpenapiParser.Spec.V3.Parameter do
   defp parse_location("cookie"), do: :cookie
   defp parse_location(_), do: nil
 
-  defp parse_schema(%{"schema" => schema_data}) when is_map(schema_data) do
+  defp parse_schema(%{:schema => schema_data}) when is_map(schema_data) do
     Schema.new(schema_data)
   end
 
   defp parse_schema(_), do: {:ok, nil}
 
-  defp parse_examples(%{"examples" => examples}) when is_map(examples) do
+  defp parse_examples(%{:examples => examples}) when is_map(examples) do
     result =
       Enum.reduce_while(examples, {:ok, %{}}, fn {key, value}, {:ok, acc} ->
         result =
-          if Map.has_key?(value, "$ref") do
+          if Map.has_key?(value, :"$ref") do
             Reference.new(value)
           else
             Example.new(value)
@@ -104,7 +106,7 @@ defmodule OpenapiParser.Spec.V3.Parameter do
 
   defp parse_examples(_), do: {:ok, nil}
 
-  defp parse_content(%{"content" => content}) when is_map(content) do
+  defp parse_content(%{:content => content}) when is_map(content) do
     result =
       Enum.reduce_while(content, {:ok, %{}}, fn {key, value}, {:ok, acc} ->
         case MediaType.new(value) do

--- a/lib/openapi_parser/spec/v3/path_item.ex
+++ b/lib/openapi_parser/spec/v3/path_item.ex
@@ -5,6 +5,7 @@ defmodule OpenapiParser.Spec.V3.PathItem do
   Describes the operations available on a single path.
   """
 
+  alias OpenapiParser.KeyNormalizer
   alias OpenapiParser.Spec.V3.{Operation, Parameter, Reference, Server}
   alias OpenapiParser.Validation
 
@@ -43,19 +44,20 @@ defmodule OpenapiParser.Spec.V3.PathItem do
   """
   @spec new(map()) :: {:ok, t()} | {:error, String.t()}
   def new(data) when is_map(data) do
-    with {:ok, get} <- parse_operation(data, "get"),
-         {:ok, put} <- parse_operation(data, "put"),
-         {:ok, post} <- parse_operation(data, "post"),
-         {:ok, delete} <- parse_operation(data, "delete"),
-         {:ok, options} <- parse_operation(data, "options"),
-         {:ok, head} <- parse_operation(data, "head"),
-         {:ok, patch} <- parse_operation(data, "patch"),
-         {:ok, trace} <- parse_operation(data, "trace"),
+    data = KeyNormalizer.normalize_shallow(data)
+    with {:ok, get} <- parse_operation(data, :get),
+         {:ok, put} <- parse_operation(data, :put),
+         {:ok, post} <- parse_operation(data, :post),
+         {:ok, delete} <- parse_operation(data, :delete),
+         {:ok, options} <- parse_operation(data, :options),
+         {:ok, head} <- parse_operation(data, :head),
+         {:ok, patch} <- parse_operation(data, :patch),
+         {:ok, trace} <- parse_operation(data, :trace),
          {:ok, servers} <- parse_servers(data),
          {:ok, parameters} <- parse_parameters(data) do
       path_item = %__MODULE__{
-        summary: Map.get(data, "summary"),
-        description: Map.get(data, "description"),
+        summary: Map.get(data, :summary),
+        description: Map.get(data, :description),
         get: get,
         put: put,
         post: post,
@@ -79,7 +81,7 @@ defmodule OpenapiParser.Spec.V3.PathItem do
     end
   end
 
-  defp parse_servers(%{"servers" => servers}) when is_list(servers) do
+  defp parse_servers(%{:servers => servers}) when is_list(servers) do
     result =
       Enum.reduce_while(servers, {:ok, []}, fn server_data, {:ok, acc} ->
         case Server.new(server_data) do
@@ -93,11 +95,11 @@ defmodule OpenapiParser.Spec.V3.PathItem do
 
   defp parse_servers(_), do: {:ok, nil}
 
-  defp parse_parameters(%{"parameters" => params}) when is_list(params) do
+  defp parse_parameters(%{:parameters => params}) when is_list(params) do
     result =
       Enum.reduce_while(params, {:ok, []}, fn param_data, {:ok, acc} ->
         result =
-          if Map.has_key?(param_data, "$ref") do
+          if Map.has_key?(param_data, :"$ref") do
             Reference.new(param_data)
           else
             Parameter.new(param_data)

--- a/lib/openapi_parser/spec/v3/path_item.ex
+++ b/lib/openapi_parser/spec/v3/path_item.ex
@@ -45,6 +45,7 @@ defmodule OpenapiParser.Spec.V3.PathItem do
   @spec new(map()) :: {:ok, t()} | {:error, String.t()}
   def new(data) when is_map(data) do
     data = KeyNormalizer.normalize_shallow(data)
+
     with {:ok, get} <- parse_operation(data, :get),
          {:ok, put} <- parse_operation(data, :put),
          {:ok, post} <- parse_operation(data, :post),

--- a/lib/openapi_parser/spec/v3/reference.ex
+++ b/lib/openapi_parser/spec/v3/reference.ex
@@ -5,6 +5,7 @@ defmodule OpenapiParser.Spec.V3.Reference do
   A simple object to allow referencing other components in the specification.
   """
 
+  alias OpenapiParser.KeyNormalizer
   alias OpenapiParser.Validation
 
   @type t :: %__MODULE__{
@@ -20,10 +21,11 @@ defmodule OpenapiParser.Spec.V3.Reference do
   """
   @spec new(map()) :: {:ok, t()} | {:error, String.t()}
   def new(data) when is_map(data) do
+    data = KeyNormalizer.normalize_shallow(data)
     reference = %__MODULE__{
-      ref: Map.get(data, "$ref"),
-      summary: Map.get(data, "summary"),
-      description: Map.get(data, "description")
+      ref: Map.get(data, :"$ref"),
+      summary: Map.get(data, :summary),
+      description: Map.get(data, :description)
     }
 
     {:ok, reference}

--- a/lib/openapi_parser/spec/v3/reference.ex
+++ b/lib/openapi_parser/spec/v3/reference.ex
@@ -22,6 +22,7 @@ defmodule OpenapiParser.Spec.V3.Reference do
   @spec new(map()) :: {:ok, t()} | {:error, String.t()}
   def new(data) when is_map(data) do
     data = KeyNormalizer.normalize_shallow(data)
+
     reference = %__MODULE__{
       ref: Map.get(data, :"$ref"),
       summary: Map.get(data, :summary),

--- a/lib/openapi_parser/spec/v3/request_body.ex
+++ b/lib/openapi_parser/spec/v3/request_body.ex
@@ -23,6 +23,7 @@ defmodule OpenapiParser.Spec.V3.RequestBody do
   @spec new(map()) :: {:ok, t()} | {:error, String.t()}
   def new(data) when is_map(data) do
     data = KeyNormalizer.normalize_shallow(data)
+
     with {:ok, content} <- parse_content(data) do
       request_body = %__MODULE__{
         description: Map.get(data, :description),

--- a/lib/openapi_parser/spec/v3/request_body.ex
+++ b/lib/openapi_parser/spec/v3/request_body.ex
@@ -5,6 +5,7 @@ defmodule OpenapiParser.Spec.V3.RequestBody do
   Describes a single request body.
   """
 
+  alias OpenapiParser.KeyNormalizer
   alias OpenapiParser.Spec.V3.MediaType
   alias OpenapiParser.Validation
 
@@ -21,18 +22,19 @@ defmodule OpenapiParser.Spec.V3.RequestBody do
   """
   @spec new(map()) :: {:ok, t()} | {:error, String.t()}
   def new(data) when is_map(data) do
+    data = KeyNormalizer.normalize_shallow(data)
     with {:ok, content} <- parse_content(data) do
       request_body = %__MODULE__{
-        description: Map.get(data, "description"),
+        description: Map.get(data, :description),
         content: content,
-        required: Map.get(data, "required", false)
+        required: Map.get(data, :required, false)
       }
 
       {:ok, request_body}
     end
   end
 
-  defp parse_content(%{"content" => content}) when is_map(content) do
+  defp parse_content(%{:content => content}) when is_map(content) do
     result =
       Enum.reduce_while(content, {:ok, %{}}, fn {key, value}, {:ok, acc} ->
         case MediaType.new(value) do

--- a/lib/openapi_parser/spec/v3/response.ex
+++ b/lib/openapi_parser/spec/v3/response.ex
@@ -24,6 +24,7 @@ defmodule OpenapiParser.Spec.V3.Response do
   @spec new(map()) :: {:ok, t()} | {:error, String.t()}
   def new(data) when is_map(data) do
     data = KeyNormalizer.normalize_shallow(data)
+
     with {:ok, headers} <- parse_headers(data),
          {:ok, content} <- parse_content(data),
          {:ok, links} <- parse_links(data) do

--- a/lib/openapi_parser/spec/v3/responses.ex
+++ b/lib/openapi_parser/spec/v3/responses.ex
@@ -5,6 +5,7 @@ defmodule OpenapiParser.Spec.V3.Responses do
   A container for the expected responses of an operation.
   """
 
+  alias OpenapiParser.KeyNormalizer
   alias OpenapiParser.Spec.V3.{Reference, Response}
   alias OpenapiParser.Validation
 
@@ -19,10 +20,11 @@ defmodule OpenapiParser.Spec.V3.Responses do
   """
   @spec new(map()) :: {:ok, t()} | {:error, String.t()}
   def new(data) when is_map(data) do
+    data = KeyNormalizer.normalize_shallow(data)
     result =
       Enum.reduce_while(data, {:ok, %{}}, fn {key, value}, {:ok, acc} ->
         result =
-          if Map.has_key?(value, "$ref") do
+          if Map.has_key?(value, :"$ref") do
             Reference.new(value)
           else
             Response.new(value)

--- a/lib/openapi_parser/spec/v3/responses.ex
+++ b/lib/openapi_parser/spec/v3/responses.ex
@@ -20,14 +20,18 @@ defmodule OpenapiParser.Spec.V3.Responses do
   """
   @spec new(map()) :: {:ok, t()} | {:error, String.t()}
   def new(data) when is_map(data) do
-    data = KeyNormalizer.normalize_shallow(data)
+    # Don't normalize keys here - they are response codes (like "200", "404", "default")
+    # which should remain as strings, not be converted to atoms
     result =
       Enum.reduce_while(data, {:ok, %{}}, fn {key, value}, {:ok, acc} ->
+        # Normalize the value before checking for $ref
+        normalized_value = KeyNormalizer.normalize_shallow(value)
+
         result =
-          if Map.has_key?(value, :"$ref") do
-            Reference.new(value)
+          if Map.has_key?(normalized_value, :"$ref") do
+            Reference.new(normalized_value)
           else
-            Response.new(value)
+            Response.new(normalized_value)
           end
 
         case result do

--- a/lib/openapi_parser/spec/v3/schema.ex
+++ b/lib/openapi_parser/spec/v3/schema.ex
@@ -6,6 +6,7 @@ defmodule OpenapiParser.Spec.V3.Schema do
   V3.0 uses JSON Schema Draft 5, V3.1 uses JSON Schema 2020-12.
   """
 
+  alias OpenapiParser.KeyNormalizer
   alias OpenapiParser.Spec.{ExternalDocumentation, V3}
   alias OpenapiParser.Validation
 
@@ -154,8 +155,9 @@ defmodule OpenapiParser.Spec.V3.Schema do
   """
   @spec new(map()) :: {:ok, t() | V3.Reference.t()} | {:error, String.t()}
   def new(data) when is_map(data) do
+    data = KeyNormalizer.normalize_shallow(data)
     # Handle $ref
-    if Map.has_key?(data, "$ref") do
+    if Map.has_key?(data, :"$ref") do
       V3.Reference.new(data)
     else
       with {:ok, items} <- parse_items(data),
@@ -170,45 +172,45 @@ defmodule OpenapiParser.Spec.V3.Schema do
            {:ok, dependent_schemas} <- parse_dependent_schemas(data),
            {:ok, if_then_else} <- parse_if_then_else(data),
            {:ok, defs} <- parse_defs(data),
-           {:ok, all_of} <- parse_composition(data, "allOf"),
-           {:ok, any_of} <- parse_composition(data, "anyOf"),
-           {:ok, one_of} <- parse_composition(data, "oneOf"),
+           {:ok, all_of} <- parse_composition(data, :allOf),
+           {:ok, any_of} <- parse_composition(data, :anyOf),
+           {:ok, one_of} <- parse_composition(data, :oneOf),
            {:ok, not_schema} <- parse_not(data),
            {:ok, external_docs} <- parse_external_docs(data),
            {:ok, discriminator} <- parse_discriminator(data),
            {:ok, xml} <- parse_xml(data) do
         schema = %__MODULE__{
-          type: parse_type(data["type"]),
-          format: Map.get(data, "format"),
-          max_length: Map.get(data, "maxLength"),
-          min_length: Map.get(data, "minLength"),
-          pattern: Map.get(data, "pattern"),
-          maximum: Map.get(data, "maximum"),
-          exclusive_maximum: Map.get(data, "exclusiveMaximum"),
-          minimum: Map.get(data, "minimum"),
-          exclusive_minimum: Map.get(data, "exclusiveMinimum"),
-          multiple_of: Map.get(data, "multipleOf"),
+          type: parse_type(data[:type]),
+          format: Map.get(data, :format),
+          max_length: Map.get(data, :maxLength),
+          min_length: Map.get(data, :minLength),
+          pattern: Map.get(data, :pattern),
+          maximum: Map.get(data, :maximum),
+          exclusive_maximum: Map.get(data, :exclusiveMaximum),
+          minimum: Map.get(data, :minimum),
+          exclusive_minimum: Map.get(data, :exclusiveMinimum),
+          multiple_of: Map.get(data, :multipleOf),
           items: items,
           prefix_items: prefix_items,
           contains: contains,
-          min_contains: Map.get(data, "minContains"),
-          max_contains: Map.get(data, "maxContains"),
+          min_contains: Map.get(data, :minContains),
+          max_contains: Map.get(data, :maxContains),
           unevaluated_items: unevaluated_items,
-          max_items: Map.get(data, "maxItems"),
-          min_items: Map.get(data, "minItems"),
-          unique_items: Map.get(data, "uniqueItems"),
+          max_items: Map.get(data, :maxItems),
+          min_items: Map.get(data, :minItems),
+          unique_items: Map.get(data, :uniqueItems),
           properties: properties,
           pattern_properties: pattern_properties,
           property_names: property_names,
           additional_properties: additional_properties,
           unevaluated_properties: unevaluated_properties,
-          required: Map.get(data, "required"),
-          max_properties: Map.get(data, "maxProperties"),
-          min_properties: Map.get(data, "minProperties"),
+          required: Map.get(data, :required),
+          max_properties: Map.get(data, :maxProperties),
+          min_properties: Map.get(data, :minProperties),
           dependent_schemas: dependent_schemas,
-          enum: Map.get(data, "enum"),
-          const: Map.get(data, "const"),
-          default: Map.get(data, "default"),
+          enum: Map.get(data, :enum),
+          const: Map.get(data, :const),
+          default: Map.get(data, :default),
           all_of: all_of,
           any_of: any_of,
           one_of: one_of,
@@ -216,27 +218,27 @@ defmodule OpenapiParser.Spec.V3.Schema do
           if_schema: if_then_else.if_schema,
           then_schema: if_then_else.then_schema,
           else_schema: if_then_else.else_schema,
-          title: Map.get(data, "title"),
-          description: Map.get(data, "description"),
-          example: Map.get(data, "example"),
-          examples: Map.get(data, "examples"),
+          title: Map.get(data, :title),
+          description: Map.get(data, :description),
+          example: Map.get(data, :example),
+          examples: Map.get(data, :examples),
           external_docs: external_docs,
-          deprecated: Map.get(data, "deprecated"),
+          deprecated: Map.get(data, :deprecated),
           discriminator: discriminator,
-          read_only: Map.get(data, "readOnly"),
-          write_only: Map.get(data, "writeOnly"),
+          read_only: Map.get(data, :readOnly),
+          write_only: Map.get(data, :writeOnly),
           xml: xml,
-          content_encoding: Map.get(data, "contentEncoding"),
-          content_media_type: Map.get(data, "contentMediaType"),
-          content_schema: Map.get(data, "contentSchema"),
+          content_encoding: Map.get(data, :contentEncoding),
+          content_media_type: Map.get(data, :contentMediaType),
+          content_schema: Map.get(data, :contentSchema),
           defs: defs,
-          id: Map.get(data, "$id"),
-          anchor: Map.get(data, "$anchor"),
-          dynamic_anchor: Map.get(data, "$dynamicAnchor"),
-          dynamic_ref: Map.get(data, "$dynamicRef"),
-          schema_uri: Map.get(data, "$schema"),
-          comment: Map.get(data, "$comment"),
-          nullable: Map.get(data, "nullable")
+          id: Map.get(data, :"$id"),
+          anchor: Map.get(data, :"$anchor"),
+          dynamic_anchor: Map.get(data, :"$dynamicAnchor"),
+          dynamic_ref: Map.get(data, :"$dynamicRef"),
+          schema_uri: Map.get(data, :"$schema"),
+          comment: Map.get(data, :"$comment"),
+          nullable: Map.get(data, :nullable)
         }
 
         {:ok, schema}
@@ -261,13 +263,13 @@ defmodule OpenapiParser.Spec.V3.Schema do
   defp parse_single_type("null"), do: :null
   defp parse_single_type(_), do: nil
 
-  defp parse_items(%{"items" => items_data}) when is_map(items_data) do
+  defp parse_items(%{:items => items_data}) when is_map(items_data) do
     new(items_data)
   end
 
   defp parse_items(_), do: {:ok, nil}
 
-  defp parse_properties(%{"properties" => props}) when is_map(props) do
+  defp parse_properties(%{:properties => props}) when is_map(props) do
     result =
       Enum.reduce_while(props, {:ok, %{}}, fn {key, value}, {:ok, acc} ->
         case new(value) do
@@ -281,27 +283,27 @@ defmodule OpenapiParser.Spec.V3.Schema do
 
   defp parse_properties(_), do: {:ok, nil}
 
-  defp parse_additional_properties(%{"additionalProperties" => false}), do: {:ok, false}
-  defp parse_additional_properties(%{"additionalProperties" => true}), do: {:ok, true}
+  defp parse_additional_properties(%{:additionalProperties => false}), do: {:ok, false}
+  defp parse_additional_properties(%{:additionalProperties => true}), do: {:ok, true}
 
-  defp parse_additional_properties(%{"additionalProperties" => schema_data})
+  defp parse_additional_properties(%{:additionalProperties => schema_data})
        when is_map(schema_data) do
     new(schema_data)
   end
 
   defp parse_additional_properties(_), do: {:ok, nil}
 
-  defp parse_unevaluated_properties(%{"unevaluatedProperties" => false}), do: {:ok, false}
-  defp parse_unevaluated_properties(%{"unevaluatedProperties" => true}), do: {:ok, true}
+  defp parse_unevaluated_properties(%{:unevaluatedProperties => false}), do: {:ok, false}
+  defp parse_unevaluated_properties(%{:unevaluatedProperties => true}), do: {:ok, true}
 
-  defp parse_unevaluated_properties(%{"unevaluatedProperties" => schema_data})
+  defp parse_unevaluated_properties(%{:unevaluatedProperties => schema_data})
        when is_map(schema_data) do
     new(schema_data)
   end
 
   defp parse_unevaluated_properties(_), do: {:ok, nil}
 
-  defp parse_prefix_items(%{"prefixItems" => prefix_items}) when is_list(prefix_items) do
+  defp parse_prefix_items(%{:prefixItems => prefix_items}) when is_list(prefix_items) do
     result =
       Enum.reduce_while(prefix_items, {:ok, []}, fn schema_data, {:ok, acc} ->
         case new(schema_data) do
@@ -315,23 +317,23 @@ defmodule OpenapiParser.Spec.V3.Schema do
 
   defp parse_prefix_items(_), do: {:ok, nil}
 
-  defp parse_contains(%{"contains" => contains_data}) when is_map(contains_data) do
+  defp parse_contains(%{:contains => contains_data}) when is_map(contains_data) do
     new(contains_data)
   end
 
   defp parse_contains(_), do: {:ok, nil}
 
-  defp parse_unevaluated_items(%{"unevaluatedItems" => false}), do: {:ok, false}
-  defp parse_unevaluated_items(%{"unevaluatedItems" => true}), do: {:ok, true}
+  defp parse_unevaluated_items(%{:unevaluatedItems => false}), do: {:ok, false}
+  defp parse_unevaluated_items(%{:unevaluatedItems => true}), do: {:ok, true}
 
-  defp parse_unevaluated_items(%{"unevaluatedItems" => schema_data})
+  defp parse_unevaluated_items(%{:unevaluatedItems => schema_data})
        when is_map(schema_data) do
     new(schema_data)
   end
 
   defp parse_unevaluated_items(_), do: {:ok, nil}
 
-  defp parse_pattern_properties(%{"patternProperties" => pattern_props})
+  defp parse_pattern_properties(%{:patternProperties => pattern_props})
        when is_map(pattern_props) do
     result =
       Enum.reduce_while(pattern_props, {:ok, %{}}, fn {pattern, value}, {:ok, acc} ->
@@ -346,13 +348,13 @@ defmodule OpenapiParser.Spec.V3.Schema do
 
   defp parse_pattern_properties(_), do: {:ok, nil}
 
-  defp parse_property_names(%{"propertyNames" => prop_names_data}) when is_map(prop_names_data) do
+  defp parse_property_names(%{:propertyNames => prop_names_data}) when is_map(prop_names_data) do
     new(prop_names_data)
   end
 
   defp parse_property_names(_), do: {:ok, nil}
 
-  defp parse_dependent_schemas(%{"dependentSchemas" => dep_schemas}) when is_map(dep_schemas) do
+  defp parse_dependent_schemas(%{:dependentSchemas => dep_schemas}) when is_map(dep_schemas) do
     result =
       Enum.reduce_while(dep_schemas, {:ok, %{}}, fn {key, value}, {:ok, acc} ->
         case new(value) do
@@ -368,13 +370,13 @@ defmodule OpenapiParser.Spec.V3.Schema do
 
   defp parse_if_then_else(data) do
     if_schema =
-      if Map.has_key?(data, "if"), do: parse_if_then_else_schema(data["if"]), else: {:ok, nil}
+      if Map.has_key?(data, :if), do: parse_if_then_else_schema(data[:if]), else: {:ok, nil}
 
     then_schema =
-      if Map.has_key?(data, "then"), do: parse_if_then_else_schema(data["then"]), else: {:ok, nil}
+      if Map.has_key?(data, :then), do: parse_if_then_else_schema(data[:then]), else: {:ok, nil}
 
     else_schema =
-      if Map.has_key?(data, "else"), do: parse_if_then_else_schema(data["else"]), else: {:ok, nil}
+      if Map.has_key?(data, :else), do: parse_if_then_else_schema(data[:else]), else: {:ok, nil}
 
     with {:ok, if_val} <- if_schema,
          {:ok, then_val} <- then_schema,
@@ -387,7 +389,7 @@ defmodule OpenapiParser.Spec.V3.Schema do
   defp parse_if_then_else_schema(schema_data) when is_map(schema_data), do: new(schema_data)
   defp parse_if_then_else_schema(_), do: {:ok, nil}
 
-  defp parse_defs(%{"$defs" => defs_data}) when is_map(defs_data) do
+  defp parse_defs(%{:"$defs" => defs_data}) when is_map(defs_data) do
     result =
       Enum.reduce_while(defs_data, {:ok, %{}}, fn {key, value}, {:ok, acc} ->
         case new(value) do
@@ -419,25 +421,25 @@ defmodule OpenapiParser.Spec.V3.Schema do
     end
   end
 
-  defp parse_not(%{"not" => not_data}) when is_map(not_data) do
+  defp parse_not(%{:not => not_data}) when is_map(not_data) do
     new(not_data)
   end
 
   defp parse_not(_), do: {:ok, nil}
 
-  defp parse_external_docs(%{"externalDocs" => docs_data}) when is_map(docs_data) do
+  defp parse_external_docs(%{:externalDocs => docs_data}) when is_map(docs_data) do
     ExternalDocumentation.new(docs_data)
   end
 
   defp parse_external_docs(_), do: {:ok, nil}
 
-  defp parse_discriminator(%{"discriminator" => disc_data}) when is_map(disc_data) do
+  defp parse_discriminator(%{:discriminator => disc_data}) when is_map(disc_data) do
     V3.Discriminator.new(disc_data)
   end
 
   defp parse_discriminator(_), do: {:ok, nil}
 
-  defp parse_xml(%{"xml" => xml_data}) when is_map(xml_data) do
+  defp parse_xml(%{:xml => xml_data}) when is_map(xml_data) do
     V3.Xml.new(xml_data)
   end
 

--- a/lib/openapi_parser/spec/v3/security_requirement.ex
+++ b/lib/openapi_parser/spec/v3/security_requirement.ex
@@ -20,6 +20,7 @@ defmodule OpenapiParser.Spec.V3.SecurityRequirement do
   @spec new(map()) :: {:ok, t()} | {:error, String.t()}
   def new(data) when is_map(data) do
     data = KeyNormalizer.normalize_shallow(data)
+
     security = %__MODULE__{
       requirements: data
     }

--- a/lib/openapi_parser/spec/v3/security_requirement.ex
+++ b/lib/openapi_parser/spec/v3/security_requirement.ex
@@ -6,6 +6,8 @@ defmodule OpenapiParser.Spec.V3.SecurityRequirement do
   Maps security scheme names to lists of required scopes.
   """
 
+  alias OpenapiParser.KeyNormalizer
+
   @type t :: %__MODULE__{
           requirements: %{String.t() => [String.t()]}
         }
@@ -17,6 +19,7 @@ defmodule OpenapiParser.Spec.V3.SecurityRequirement do
   """
   @spec new(map()) :: {:ok, t()} | {:error, String.t()}
   def new(data) when is_map(data) do
+    data = KeyNormalizer.normalize_shallow(data)
     security = %__MODULE__{
       requirements: data
     }

--- a/lib/openapi_parser/spec/v3/security_scheme.ex
+++ b/lib/openapi_parser/spec/v3/security_scheme.ex
@@ -43,6 +43,7 @@ defmodule OpenapiParser.Spec.V3.SecurityScheme do
   @spec new(map()) :: {:ok, t()} | {:error, String.t()}
   def new(data) when is_map(data) do
     data = KeyNormalizer.normalize_shallow(data)
+
     with {:ok, flows} <- parse_flows(data) do
       scheme = %__MODULE__{
         type: parse_type(data[:type]),

--- a/lib/openapi_parser/spec/v3/security_scheme.ex
+++ b/lib/openapi_parser/spec/v3/security_scheme.ex
@@ -5,6 +5,7 @@ defmodule OpenapiParser.Spec.V3.SecurityScheme do
   Defines a security scheme that can be used by the operations.
   """
 
+  alias OpenapiParser.KeyNormalizer
   alias OpenapiParser.Spec.V3.OAuthFlows
   alias OpenapiParser.Validation
 
@@ -41,16 +42,17 @@ defmodule OpenapiParser.Spec.V3.SecurityScheme do
   """
   @spec new(map()) :: {:ok, t()} | {:error, String.t()}
   def new(data) when is_map(data) do
+    data = KeyNormalizer.normalize_shallow(data)
     with {:ok, flows} <- parse_flows(data) do
       scheme = %__MODULE__{
-        type: parse_type(data["type"]),
-        description: Map.get(data, "description"),
-        name: Map.get(data, "name"),
-        location: parse_location(data["in"]),
-        scheme: Map.get(data, "scheme"),
-        bearer_format: Map.get(data, "bearerFormat"),
+        type: parse_type(data[:type]),
+        description: Map.get(data, :description),
+        name: Map.get(data, :name),
+        location: parse_location(data[:in]),
+        scheme: Map.get(data, :scheme),
+        bearer_format: Map.get(data, :bearerFormat),
         flows: flows,
-        open_id_connect_url: Map.get(data, "openIdConnectUrl")
+        open_id_connect_url: Map.get(data, :openIdConnectUrl)
       }
 
       {:ok, scheme}
@@ -69,7 +71,7 @@ defmodule OpenapiParser.Spec.V3.SecurityScheme do
   defp parse_location("cookie"), do: :cookie
   defp parse_location(_), do: nil
 
-  defp parse_flows(%{"flows" => flows_data}) when is_map(flows_data) do
+  defp parse_flows(%{:flows => flows_data}) when is_map(flows_data) do
     OAuthFlows.new(flows_data)
   end
 

--- a/lib/openapi_parser/spec/v3/server.ex
+++ b/lib/openapi_parser/spec/v3/server.ex
@@ -5,6 +5,7 @@ defmodule OpenapiParser.Spec.V3.Server do
   Represents a Server.
   """
 
+  alias OpenapiParser.KeyNormalizer
   alias OpenapiParser.Spec.V3.ServerVariable
   alias OpenapiParser.Validation
 
@@ -21,10 +22,11 @@ defmodule OpenapiParser.Spec.V3.Server do
   """
   @spec new(map()) :: {:ok, t()} | {:error, String.t()}
   def new(data) when is_map(data) do
+    data = KeyNormalizer.normalize_shallow(data)
     with {:ok, variables} <- parse_variables(data) do
       server = %__MODULE__{
-        url: Map.get(data, "url"),
-        description: Map.get(data, "description"),
+        url: Map.get(data, :url),
+        description: Map.get(data, :description),
         variables: variables
       }
 
@@ -32,7 +34,7 @@ defmodule OpenapiParser.Spec.V3.Server do
     end
   end
 
-  defp parse_variables(%{"variables" => vars}) when is_map(vars) do
+  defp parse_variables(%{:variables => vars}) when is_map(vars) do
     result =
       Enum.reduce_while(vars, {:ok, %{}}, fn {key, value}, {:ok, acc} ->
         case ServerVariable.new(value) do

--- a/lib/openapi_parser/spec/v3/server.ex
+++ b/lib/openapi_parser/spec/v3/server.ex
@@ -23,6 +23,7 @@ defmodule OpenapiParser.Spec.V3.Server do
   @spec new(map()) :: {:ok, t()} | {:error, String.t()}
   def new(data) when is_map(data) do
     data = KeyNormalizer.normalize_shallow(data)
+
     with {:ok, variables} <- parse_variables(data) do
       server = %__MODULE__{
         url: Map.get(data, :url),

--- a/lib/openapi_parser/spec/v3/server_variable.ex
+++ b/lib/openapi_parser/spec/v3/server_variable.ex
@@ -22,6 +22,7 @@ defmodule OpenapiParser.Spec.V3.ServerVariable do
   @spec new(map()) :: {:ok, t()} | {:error, String.t()}
   def new(data) when is_map(data) do
     data = KeyNormalizer.normalize_shallow(data)
+
     variable = %__MODULE__{
       enum: Map.get(data, :enum),
       default: Map.get(data, :default),

--- a/lib/openapi_parser/spec/v3/server_variable.ex
+++ b/lib/openapi_parser/spec/v3/server_variable.ex
@@ -5,6 +5,7 @@ defmodule OpenapiParser.Spec.V3.ServerVariable do
   An object representing a Server Variable for server URL template substitution.
   """
 
+  alias OpenapiParser.KeyNormalizer
   alias OpenapiParser.Validation
 
   @type t :: %__MODULE__{
@@ -20,10 +21,11 @@ defmodule OpenapiParser.Spec.V3.ServerVariable do
   """
   @spec new(map()) :: {:ok, t()} | {:error, String.t()}
   def new(data) when is_map(data) do
+    data = KeyNormalizer.normalize_shallow(data)
     variable = %__MODULE__{
-      enum: Map.get(data, "enum"),
-      default: Map.get(data, "default"),
-      description: Map.get(data, "description")
+      enum: Map.get(data, :enum),
+      default: Map.get(data, :default),
+      description: Map.get(data, :description)
     }
 
     {:ok, variable}

--- a/lib/openapi_parser/spec/v3/xml.ex
+++ b/lib/openapi_parser/spec/v3/xml.ex
@@ -22,6 +22,7 @@ defmodule OpenapiParser.Spec.V3.Xml do
   @spec new(map()) :: {:ok, t()} | {:error, String.t()}
   def new(data) when is_map(data) do
     data = KeyNormalizer.normalize_shallow(data)
+
     xml = %__MODULE__{
       name: Map.get(data, :name),
       namespace: Map.get(data, :namespace),

--- a/lib/openapi_parser/spec/v3/xml.ex
+++ b/lib/openapi_parser/spec/v3/xml.ex
@@ -3,6 +3,7 @@ defmodule OpenapiParser.Spec.V3.Xml do
   XML Object for OpenAPI V3.
   """
 
+  alias OpenapiParser.KeyNormalizer
   alias OpenapiParser.Validation
 
   @type t :: %__MODULE__{
@@ -20,12 +21,13 @@ defmodule OpenapiParser.Spec.V3.Xml do
   """
   @spec new(map()) :: {:ok, t()} | {:error, String.t()}
   def new(data) when is_map(data) do
+    data = KeyNormalizer.normalize_shallow(data)
     xml = %__MODULE__{
-      name: Map.get(data, "name"),
-      namespace: Map.get(data, "namespace"),
-      prefix: Map.get(data, "prefix"),
-      attribute: Map.get(data, "attribute"),
-      wrapped: Map.get(data, "wrapped")
+      name: Map.get(data, :name),
+      namespace: Map.get(data, :namespace),
+      prefix: Map.get(data, :prefix),
+      attribute: Map.get(data, :attribute),
+      wrapped: Map.get(data, :wrapped)
     }
 
     {:ok, xml}

--- a/lib/openapi_parser/spec/v3_0/openapi.ex
+++ b/lib/openapi_parser/spec/v3_0/openapi.ex
@@ -8,6 +8,7 @@ defmodule OpenapiParser.Spec.V3_0.OpenAPI do
   For now, it simply delegates to V3.OpenAPI since the structures are the same.
   """
 
+  alias OpenapiParser.KeyNormalizer
   alias OpenapiParser.Spec.V3
 
   @type t :: V3.OpenAPI.t()

--- a/test/openapi_parser_test.exs
+++ b/test/openapi_parser_test.exs
@@ -27,8 +27,7 @@ defmodule OpenapiParserTest do
       }
       """
 
-      assert {:ok, %Spec.OpenAPI{version: :v3_1}} =
-               OpenapiParser.parse(spec, format: :json)
+      assert {:ok, %Spec.OpenAPI{version: :v3_1}} = OpenapiParser.parse(spec, format: :json)
     end
 
     test "parses OpenAPI 3.0 JSON" do
@@ -53,8 +52,7 @@ defmodule OpenapiParserTest do
       }
       """
 
-      assert {:ok, %Spec.OpenAPI{version: :v3_0}} =
-               OpenapiParser.parse(spec, format: :json)
+      assert {:ok, %Spec.OpenAPI{version: :v3_0}} = OpenapiParser.parse(spec, format: :json)
     end
 
     test "parses Swagger 2.0 JSON" do
@@ -79,8 +77,7 @@ defmodule OpenapiParserTest do
       }
       """
 
-      assert {:ok, %Spec.OpenAPI{version: :v2}} =
-               OpenapiParser.parse(spec, format: :json)
+      assert {:ok, %Spec.OpenAPI{version: :v2}} = OpenapiParser.parse(spec, format: :json)
     end
 
     test "parses YAML format" do

--- a/test/validation_test.exs
+++ b/test/validation_test.exs
@@ -331,8 +331,7 @@ defmodule OpenapiParser.ValidationTest do
     end
 
     test "validates external file references with fragment" do
-      assert :ok =
-               Validation.validate_reference("./schemas/user.json#/User", "field")
+      assert :ok = Validation.validate_reference("./schemas/user.json#/User", "field")
 
       assert :ok = Validation.validate_reference("../common.yaml#/definitions/Error", "field")
     end
@@ -375,8 +374,7 @@ defmodule OpenapiParser.ValidationTest do
     end
 
     test "validates vendor-specific types" do
-      assert :ok =
-               Validation.validate_content_type("application/vnd.api+json", "field")
+      assert :ok = Validation.validate_content_type("application/vnd.api+json", "field")
 
       assert :ok =
                Validation.validate_content_type(


### PR DESCRIPTION
Normalize all OpenAPI specification keys to atoms during parsing to simplify data access and improve code consistency.

The previous parsing approach resulted in a mix of string and atom keys, requiring defensive `Map.get(data, :key) || Map.get(data, "key")` logic throughout the codebase. This PR introduces a `KeyNormalizer` module that converts all *known* OpenAPI keywords to atoms immediately after JSON/YAML decoding. User-defined keys (e.g., schema or property names) are kept as strings to prevent atom table exhaustion. This change significantly cleans up spec module implementations and ensures a consistent data structure.

---
<a href="https://cursor.com/background-agent?bcId=bc-d51560bb-6d81-44fa-88c0-6a86c48011ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d51560bb-6d81-44fa-88c0-6a86c48011ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

